### PR TITLE
return nulls early from UnknownAsNull

### DIFF
--- a/cty/unknown_as_null.go
+++ b/cty/unknown_as_null.go
@@ -8,12 +8,12 @@ package cty
 // represent unknowns, such as JSON, as long as the caller does not need to
 // retain the unknown value information.
 func UnknownAsNull(val Value) Value {
-	if !val.IsKnown() {
-		return NullVal(val.Type())
-	}
-
 	ty := val.Type()
 	switch {
+	case val.IsNull():
+		return val
+	case !val.IsKnown():
+		return NullVal(ty)
 	case ty.IsListType() || ty.IsTupleType() || ty.IsSetType():
 		length := val.LengthInt()
 		if length == 0 {

--- a/cty/unknown_as_null_test.go
+++ b/cty/unknown_as_null_test.go
@@ -27,6 +27,10 @@ func TestUnknownAsNull(t *testing.T) {
 			NullVal(DynamicPseudoType),
 		},
 		{
+			NullVal(Object(map[string]Type{"test": String})),
+			NullVal(Object(map[string]Type{"test": String})),
+		},
+		{
 			DynamicVal,
 			NullVal(DynamicPseudoType),
 		},


### PR DESCRIPTION
If a null object type is passed in, we need to return early in order to
prevent using ElementIterator on a null value.