### PR TITLE
handle missing values during unmarshal

### DIFF
--- a/cty/msgpack/unmarshal.go
+++ b/cty/msgpack/unmarshal.go
@@ -138,7 +138,10 @@ func unmarshalList(dec *msgpack.Decoder, ety cty.Type, path cty.Path) (cty.Value
 		return cty.DynamicVal, path.NewErrorf("a list is required")
 	}
 
-	if length == 0 {
+	switch {
+	case length < 0:
+		return cty.NullVal(cty.List(ety)), nil
+	case length == 0:
 		return cty.ListValEmpty(ety), nil
 	}
 
@@ -166,7 +169,10 @@ func unmarshalSet(dec *msgpack.Decoder, ety cty.Type, path cty.Path) (cty.Value,
 		return cty.DynamicVal, path.NewErrorf("a set is required")
 	}
 
-	if length == 0 {
+	switch {
+	case length < 0:
+		return cty.NullVal(cty.Set(ety)), nil
+	case length == 0:
 		return cty.SetValEmpty(ety), nil
 	}
 
@@ -194,7 +200,10 @@ func unmarshalMap(dec *msgpack.Decoder, ety cty.Type, path cty.Path) (cty.Value,
 		return cty.DynamicVal, path.NewErrorf("a map is required")
 	}
 
-	if length == 0 {
+	switch {
+	case length < 0:
+		return cty.NullVal(cty.Map(ety)), nil
+	case length == 0:
 		return cty.MapValEmpty(ety), nil
 	}
 
@@ -227,7 +236,12 @@ func unmarshalTuple(dec *msgpack.Decoder, etys []cty.Type, path cty.Path) (cty.V
 		return cty.DynamicVal, path.NewErrorf("a tuple is required")
 	}
 
-	if length != len(etys) {
+	switch {
+	case length < 0:
+		return cty.NullVal(cty.Tuple(etys)), nil
+	case length == 0:
+		return cty.TupleVal(nil), nil
+	case length != len(etys):
 		return cty.DynamicVal, path.NewErrorf("a tuple of length %d is required", len(etys))
 	}
 
@@ -256,7 +270,12 @@ func unmarshalObject(dec *msgpack.Decoder, atys map[string]cty.Type, path cty.Pa
 		return cty.DynamicVal, path.NewErrorf("an object is required")
 	}
 
-	if length != len(atys) {
+	switch {
+	case length < 0:
+		return cty.NullVal(cty.Object(atys)), nil
+	case length == 0:
+		return cty.ObjectVal(nil), nil
+	case length != len(atys):
 		return cty.DynamicVal, path.NewErrorf("an object with %d attributes is required", len(atys))
 	}
 
@@ -293,7 +312,10 @@ func unmarshalDynamic(dec *msgpack.Decoder, path cty.Path) (cty.Value, error) {
 		return cty.DynamicVal, path.NewError(err)
 	}
 
-	if length != 2 {
+	switch {
+	case length == -1:
+		return cty.NullVal(cty.DynamicPseudoType), nil
+	case length != 2:
 		return cty.DynamicVal, path.NewErrorf(
 			"dynamic value array must have exactly two elements",
 		)


### PR DESCRIPTION
While a length of 0 should be an empty value, a length of -1 indicates
a null or missing value, and we should return a NullVal.