### PR TITLE
Add Path helper functions

### DIFF
--- a/cty/path.go
+++ b/cty/path.go
@@ -121,6 +121,14 @@ func (p Path) Copy() Path {
 	return ret
 }
 
+func (p Path) Append(step PathStep) Path {
+	return append(p, step)
+}
+
+func (p Path) Prepend(step PathStep) Path {
+	return append(Path{step}, p...)
+}
+
 func (p Path) String() string {
 	parts := make([]string, 0)
 	i := 0

--- a/cty/path.go
+++ b/cty/path.go
@@ -3,6 +3,8 @@ package cty
 import (
 	"errors"
 	"fmt"
+	"math/big"
+	"strings"
 )
 
 // A Path is a sequence of operations to locate a nested value within a
@@ -117,6 +119,38 @@ func (p Path) Copy() Path {
 	ret := make(Path, len(p))
 	copy(ret, p)
 	return ret
+}
+
+func (p Path) String() string {
+	parts := make([]string, 0)
+	i := 0
+	for _, ps := range p {
+		switch step := ps.(type) {
+		case GetAttrStep:
+			parts = append(parts, step.Name)
+			i++
+		case IndexStep:
+			idxKey := step.Key
+			keyType := idxKey.Type()
+			switch keyType {
+			case String:
+				parts[i-1] = fmt.Sprintf("%s[%q]", parts[i-1], idxKey.AsString())
+			case Number:
+				bf := idxKey.AsBigFloat()
+				idx, accuracy := bf.Int64()
+				if accuracy != big.Exact || idx < 0 {
+					panic("element key for list must be non-negative integer")
+				}
+				parts[i-1] = fmt.Sprintf("%s[%d]", parts[i-1], idx)
+			default:
+				parts[i-1] = fmt.Sprintf("%s[<%q>]", parts[i-1], keyType)
+			}
+		default:
+			parts = append(parts, fmt.Sprintf("<%T>", step))
+			i++
+		}
+	}
+	return strings.Join(parts, ".")
 }
 
 // IndexStep is a Step implementation representing applying the index operation

--- a/cty/path_test.go
+++ b/cty/path_test.go
@@ -1,0 +1,50 @@
+package cty
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPathString(t *testing.T) {
+	testCases := []struct {
+		Path           Path
+		ExpectedOutput string
+	}{
+		{
+			Path{},
+			"",
+		},
+		{
+			Path{
+				GetAttrStep{Name: "example"},
+				GetAttrStep{Name: "subkey"},
+			},
+			`example.subkey`,
+		},
+		{
+			Path{
+				GetAttrStep{Name: "example"},
+				GetAttrStep{Name: "subkey"},
+				IndexStep{Key: StringVal("strKey")},
+			},
+			`example.subkey["strKey"]`,
+		},
+		{
+			Path{
+				GetAttrStep{Name: "example"},
+				GetAttrStep{Name: "a_list"},
+				IndexStep{Key: NumberIntVal(5)},
+			},
+			`example.a_list[5]`,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			given := tc.Path.String()
+			if given != tc.ExpectedOutput {
+				t.Fatalf("Expected %q, given: %q", tc.ExpectedOutput, given)
+			}
+		})
+	}
+}

--- a/cty/path_test.go
+++ b/cty/path_test.go
@@ -48,3 +48,23 @@ func TestPathString(t *testing.T) {
 		})
 	}
 }
+
+func TestPathPrepend(t *testing.T) {
+	p := Path{
+		GetAttrStep{Name: "key"},
+	}
+	given := p.Prepend(GetAttrStep{Name: "parent"})
+	if given.String() != "parent.key" {
+		t.Fatalf("Expected: %q, given: %q", "parent.key", given.String())
+	}
+}
+
+func TestPathAppend(t *testing.T) {
+	p := Path{
+		GetAttrStep{Name: "key"},
+	}
+	given := p.Append(GetAttrStep{Name: "subkey"})
+	if given.String() != "key.subkey" {
+		t.Fatalf("Expected: %q, given: %q", "key.subkey", given.String())
+	}
+}


### PR DESCRIPTION
This PR introduces 3 new methods for `Path` - `Append`, `Prepend` and `String`.
All three would be useful in https://github.com/hashicorp/terraform/pull/19437

I'm not sure if the logic in `String()` actually belongs to `go-cty` 🤔
I'm seeking some feedback on this. I only made the decision for convenience as its shown in the linked PR. I'm totally willing to move the logic somewhere to Terraform.