### PR TITLE
handle more null values in Equals

### DIFF
--- a/cty/value_ops.go
+++ b/cty/value_ops.go
@@ -74,6 +74,12 @@ func (val Value) GoString() string {
 // as dynamic if either of the given values are. Use RawEquals to compare
 // if two values are equal *ignoring* the short-circuit rules.
 func (val Value) Equals(other Value) Value {
+	// If only one is null, then we know this must be false
+	// val.IsNull() XOR other.IsNull()
+	if (val.IsNull() || other.IsNull()) && !(val.IsNull() && other.IsNull()) {
+		return BoolVal(false)
+	}
+
 	if val.ty.HasDynamicTypes() || other.ty.HasDynamicTypes() {
 		return UnknownVal(Bool)
 	}
@@ -86,11 +92,9 @@ func (val Value) Equals(other Value) Value {
 		return UnknownVal(Bool)
 	}
 
-	if val.IsNull() || other.IsNull() {
-		if val.IsNull() && other.IsNull() {
-			return BoolVal(true)
-		}
-		return BoolVal(false)
+	// The types are equal, so the Nulls are equal.
+	if val.IsNull() && other.IsNull() {
+		return BoolVal(true)
 	}
 
 	ty := val.ty

--- a/cty/value_ops_test.go
+++ b/cty/value_ops_test.go
@@ -573,6 +573,46 @@ func TestValueEquals(t *testing.T) {
 			}),
 			UnknownVal(Bool),
 		},
+		{
+			NullVal(String),
+			NullVal(DynamicPseudoType),
+			UnknownVal(Bool),
+		},
+		{
+			NullVal(String),
+			NullVal(String),
+			True,
+		},
+		{
+			UnknownVal(String),
+			UnknownVal(Number),
+			False,
+		},
+		{
+			StringVal(""),
+			NullVal(DynamicPseudoType),
+			False,
+		},
+		{
+			StringVal(""),
+			NullVal(String),
+			False,
+		},
+		{
+			StringVal(""),
+			UnknownVal(String),
+			UnknownVal(Bool),
+		},
+		{
+			NullVal(DynamicPseudoType),
+			NullVal(DynamicPseudoType),
+			UnknownVal(Bool),
+		},
+		{
+			StringVal(""),
+			UnknownVal(Number),
+			False,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
If only one value is Null regardless of type, then the result must be
False.