### PR TITLE
Don't convert null values to cty.DynamicPseudoType

### DIFF
--- a/cty/convert/conversion.go
+++ b/cty/convert/conversion.go
@@ -21,6 +21,11 @@ func getConversion(in cty.Type, out cty.Type, unsafe bool) conversion {
 			return cty.UnknownVal(out), nil
 		}
 		if in.IsNull() {
+			// If the output is a DynamicPseudoType, the type doesn't matter,
+			// so retain the type for proper null comparison.
+			if out == cty.DynamicPseudoType {
+				return in, nil
+			}
 			// We'll pass through nulls, albeit type converted, and let
 			// the caller deal with whatever handling they want to do in
 			// case null values are considered valid in some applications.

--- a/cty/convert/public_test.go
+++ b/cty/convert/public_test.go
@@ -425,6 +425,11 @@ func TestConvert(t *testing.T) {
 			}),
 			WantError: true, // recursive conversion from bool to number is impossible
 		},
+		{
+			Value: cty.NullVal(cty.String),
+			Type:  cty.DynamicPseudoType,
+			Want:  cty.NullVal(cty.String),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
When the conversion output is DynamicPseudoType, don't convert null
values, as the output type doesn't matter and we lose the only
information available for comparison.