### PR TITLE
convert empty tuple to empty set

### DIFF
--- a/cty/convert/conversion_collection.go
+++ b/cty/convert/conversion_collection.go
@@ -138,7 +138,7 @@ func conversionTupleToSet(tupleType cty.Type, listEty cty.Type, unsafe bool) con
 	if len(tupleEtys) == 0 {
 		// Empty tuple short-circuit
 		return func(val cty.Value, path cty.Path) (cty.Value, error) {
-			return cty.ListValEmpty(listEty), nil
+			return cty.SetValEmpty(listEty), nil
 		}
 	}
 

--- a/cty/convert/public_test.go
+++ b/cty/convert/public_test.go
@@ -493,6 +493,11 @@ func TestConvert(t *testing.T) {
 			}),
 			WantError: true,
 		},
+		{
+			Value: cty.EmptyTupleVal,
+			Type:  cty.Set(cty.String),
+			Want:  cty.SetValEmpty(cty.String),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Converting an empty tuple value to a set should result in an empty set, not an
empty list.