### PR TITLE
cty/diff: implement diff package

### DIFF
--- a/cty/diff/change.go
+++ b/cty/diff/change.go
@@ -1,6 +1,9 @@
 package diff
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -11,6 +14,7 @@ import (
 // implementations are those within this package.
 type Change interface {
 	changeSigil() changeImpl
+	apply(val cty.Value) (cty.Value, error)
 }
 
 // Embed changeImpl into a struct to make it a Change implementation
@@ -32,6 +36,67 @@ type ReplaceChange struct {
 	NewValue cty.Value
 }
 
+func (c ReplaceChange) apply(val cty.Value) (cty.Value, error) {
+	if len(c.Path) == 0 {
+		// Empty path, replace entire value.
+		if !val.RawEquals(c.OldValue) {
+			return cty.NilVal, errors.New("existing value does not match")
+		}
+		return c.NewValue, nil
+	}
+	parent, _ := c.Path[:len(c.Path)-1].Apply(val)
+	if !c.OldValue.IsNull() || !parent.Type().IsMapType() {
+		// Compare existing.
+		existing, err := c.Path.Apply(val)
+		if err != nil {
+			return cty.NilVal, c.Path.NewErrorf("path does not exist in value")
+		}
+		if !existing.RawEquals(c.OldValue) {
+			return cty.NilVal, c.Path.NewErrorf("existing value does not match")
+		}
+	}
+	key := c.Path[len(c.Path)-1]
+	ty := parent.Type()
+	switch {
+	case ty.IsObjectType():
+		kv := parent.AsValueMap()
+		kv[key.(cty.GetAttrStep).Name] = c.NewValue
+		return cty.ObjectVal(kv), nil
+	case ty.IsMapType():
+		kv := parent.AsValueMap()
+		if kv == nil {
+			kv = make(map[string]cty.Value)
+		}
+		kv[key.(cty.IndexStep).Key.AsString()] = c.NewValue
+		return cty.MapVal(kv), nil
+	case ty.IsListType():
+		var vv []cty.Value
+		idx := key.(cty.IndexStep).Key
+		for it := parent.ElementIterator(); it.Next(); {
+			i, ev := it.Element()
+			if i.RawEquals(idx) {
+				vv = append(vv, c.NewValue)
+				continue
+			}
+			vv = append(vv, ev)
+		}
+		return cty.ListVal(vv), nil
+	case ty.IsTupleType():
+		var vv []cty.Value
+		idx := key.(cty.IndexStep).Key
+		for it := parent.ElementIterator(); it.Next(); {
+			i, ev := it.Element()
+			if i.RawEquals(idx) {
+				vv = append(vv, c.NewValue)
+				continue
+			}
+			vv = append(vv, ev)
+		}
+		return cty.TupleVal(vv), nil
+	}
+	panic(fmt.Sprintf("Not supported: %s", ty.FriendlyName()))
+}
+
 // DeleteChange is a Change implementation that represents removing an
 // element from an indexable collection.
 //
@@ -47,6 +112,55 @@ type DeleteChange struct {
 	OldValue cty.Value
 }
 
+func (c DeleteChange) apply(val cty.Value) (cty.Value, error) {
+	// Compare existing.
+	existing, err := c.Path.Apply(val)
+	if err != nil {
+		return cty.NilVal, c.Path.NewErrorf("path does not exist in value")
+	}
+	if !existing.RawEquals(c.OldValue) {
+		return cty.NilVal, c.Path.NewErrorf("existing value does not match")
+	}
+	parent, _ := c.Path[:len(c.Path)-1].Apply(val)
+	key := c.Path[len(c.Path)-1]
+	ty := parent.Type()
+	switch {
+	case ty.IsObjectType():
+		kv := parent.AsValueMap()
+		delete(kv, key.(cty.GetAttrStep).Name)
+		return cty.ObjectVal(kv), nil
+	case ty.IsMapType():
+		kv := parent.AsValueMap()
+		delete(kv, key.(cty.IndexStep).Key.AsString())
+		return cty.MapVal(kv), nil
+	case ty.IsListType():
+		var vv []cty.Value
+		idx := key.(cty.IndexStep).Key
+		for it := parent.ElementIterator(); it.Next(); {
+			i, ev := it.Element()
+			if i.RawEquals(idx) {
+				// Skip
+				continue
+			}
+			vv = append(vv, ev)
+		}
+		return cty.ListVal(vv), nil
+	case ty.IsTupleType():
+		var vv []cty.Value
+		idx := key.(cty.IndexStep).Key
+		for it := parent.ElementIterator(); it.Next(); {
+			i, ev := it.Element()
+			if i.RawEquals(idx) {
+				// Skip
+				continue
+			}
+			vv = append(vv, ev)
+		}
+		return cty.TupleVal(vv), nil
+	}
+	return cty.NilVal, c.Path.NewErrorf("value is not indexable")
+}
+
 // InsertChange is a Change implementation that represents inserting a new
 // element into a list.
 //
@@ -59,12 +173,65 @@ type InsertChange struct {
 	BeforeValue cty.Value
 }
 
+func (c InsertChange) apply(val cty.Value) (cty.Value, error) {
+	list, err := c.Path.Apply(val)
+	if err != nil {
+		return cty.NilVal, c.Path.NewErrorf("path does not exist in value")
+	}
+	if !list.CanIterateElements() {
+		return cty.NilVal, c.Path.NewErrorf("value is not iterable")
+	}
+	ty := list.Type()
+	vals := list.AsValueSlice()
+	out := make([]cty.Value, 0, len(vals)+1)
+	if len(vals) == 0 && c.BeforeValue.IsNull() {
+		if ty.IsListType() {
+			if !c.BeforeValue.Type().Equals(ty.ElementType()) {
+				return cty.NilVal, c.Path.NewErrorf("before value must be a %s", ty.ElementType())
+			}
+		}
+		out = append(out, c.NewValue)
+	} else {
+		match := false
+		for _, v := range vals {
+			if v.RawEquals(c.BeforeValue) && !match {
+				out = append(out, c.NewValue)
+				match = true
+			}
+			out = append(out, v)
+		}
+		if !match {
+			return cty.NilVal, c.Path.NewErrorf("before value does not exist")
+		}
+	}
+	switch {
+	case ty.IsListType():
+		return cty.ListVal(out), nil
+	case ty.IsTupleType():
+		return cty.TupleVal(out), nil
+	}
+	panic(fmt.Sprintf("Not supported: %s", ty.FriendlyName()))
+}
+
 // AddChange is a Change implementation that represents adding a value to
 // a set. The Path is to the set itself, and NewValue is the value to insert.
 type AddChange struct {
 	changeImpl
 	Path     cty.Path
 	NewValue cty.Value
+}
+
+func (c AddChange) apply(val cty.Value) (cty.Value, error) {
+	set, err := c.Path.Apply(val)
+	if err != nil {
+		return cty.NilVal, c.Path.NewErrorf("path does not exist in value")
+	}
+	if !set.Type().IsSetType() {
+		return cty.NilVal, c.Path.NewErrorf("value is not a set")
+	}
+	s := set.AsValueSet()
+	s.Add(c.NewValue)
+	return cty.SetVal(s.Values()), nil
 }
 
 // RemoveChange is a Change implementation that represents removing a value
@@ -80,6 +247,22 @@ type RemoveChange struct {
 	changeImpl
 	Path     cty.Path
 	OldValue cty.Value
+}
+
+func (c RemoveChange) apply(val cty.Value) (cty.Value, error) {
+	set, err := c.Path.Apply(val)
+	if err != nil {
+		return cty.NilVal, c.Path.NewErrorf("path does not exist in value")
+	}
+	if !set.Type().IsSetType() {
+		return cty.NilVal, c.Path.NewErrorf("value is not a set")
+	}
+	s := set.AsValueSet()
+	if !s.Has(c.OldValue) {
+		return cty.NilVal, c.Path.NewErrorf("old value does not exist")
+	}
+	s.Remove(c.OldValue)
+	return cty.SetVal(s.Values()), nil
 }
 
 // NestedDiff is a Change implementation that applies a nested diff to a
@@ -105,6 +288,10 @@ type NestedDiff struct {
 	Diff     Diff
 }
 
+func (c NestedDiff) apply(val cty.Value) (cty.Value, error) {
+	return cty.NullVal(val.Type()), errors.New("not yet implemented")
+}
+
 // Context is a funny sort of Change implementation that doesn't actually
 // change anything but fails if the value at the given path doesn't match
 // the given value.
@@ -115,4 +302,15 @@ type Context struct {
 	changeImpl
 	Path      cty.Path
 	WantValue cty.Value
+}
+
+func (c Context) apply(val cty.Value) (cty.Value, error) {
+	existing, err := c.Path.Apply(val)
+	if err != nil {
+		return cty.NilVal, c.Path.NewErrorf("path does not exist in value")
+	}
+	if !existing.RawEquals(c.WantValue) {
+		return cty.NilVal, c.Path.NewErrorf("existing value does not match")
+	}
+	return val, nil
 }

--- a/cty/diff/diff.go
+++ b/cty/diff/diff.go
@@ -1,8 +1,6 @@
 package diff
 
 import (
-	"errors"
-
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -37,7 +35,15 @@ func NewDiff(source, target cty.Value) Diff {
 // source value. If any one change fails then the entire operation is
 // considered to have failed.
 func (d Diff) Apply(source cty.Value) (cty.Value, error) {
-	return cty.NullVal(source.Type()), errors.New("not yet implemented")
+	val := source
+	for _, c := range d {
+		v, err := c.apply(val)
+		if err != nil {
+			return cty.NilVal, err
+		}
+		val = v
+	}
+	return val, nil
 }
 
 // Replace returns a copy of the receiver with a ReplaceChange appended.

--- a/cty/diff/diff_test.go
+++ b/cty/diff/diff_test.go
@@ -1,1 +1,237 @@
 package diff
+
+import (
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestDiff_Apply(t *testing.T) {
+	tests := []struct {
+		name   string
+		diff   Diff
+		source cty.Value
+		want   cty.Value
+	}{
+		// Replace
+		{
+			"ReplaceString",
+			Diff{
+				ReplaceChange{
+					Path:     nil,
+					OldValue: cty.StringVal("A"),
+					NewValue: cty.StringVal("B"),
+				},
+			},
+			cty.StringVal("A"),
+			cty.StringVal("B"),
+		},
+		{
+			"ReplaceObject",
+			Diff{
+				ReplaceChange{
+					Path:     cty.GetAttrPath("a"),
+					OldValue: cty.StringVal("A"),
+					NewValue: cty.StringVal("B"),
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{"a": cty.StringVal("A")}),
+			cty.ObjectVal(map[string]cty.Value{"a": cty.StringVal("B")}),
+		},
+		{
+			"ReplaceMapAdd",
+			Diff{
+				ReplaceChange{
+					Path:     cty.IndexPath(cty.StringVal("a")),
+					OldValue: cty.NullVal(cty.String),
+					NewValue: cty.StringVal("A"),
+				},
+			},
+			cty.MapValEmpty(cty.String),
+			cty.MapVal(map[string]cty.Value{"a": cty.StringVal("A")}),
+		},
+		{
+			"ReplaceMapUpdate",
+			Diff{
+				ReplaceChange{
+					Path:     cty.IndexPath(cty.StringVal("a")),
+					OldValue: cty.StringVal("A"),
+					NewValue: cty.StringVal("B"),
+				},
+			},
+			cty.MapVal(map[string]cty.Value{"a": cty.StringVal("A")}),
+			cty.MapVal(map[string]cty.Value{"a": cty.StringVal("B")}),
+		},
+		{
+			"ReplaceList",
+			Diff{
+				ReplaceChange{
+					Path:     cty.IndexPath(cty.NumberIntVal(1)),
+					OldValue: cty.StringVal("B"),
+					NewValue: cty.StringVal("X"),
+				},
+			},
+			cty.ListVal([]cty.Value{cty.StringVal("A"), cty.StringVal("B"), cty.StringVal("C")}),
+			cty.ListVal([]cty.Value{cty.StringVal("A"), cty.StringVal("X"), cty.StringVal("C")}),
+		},
+		{
+			"ReplaceTuple",
+			Diff{
+				ReplaceChange{
+					Path:     cty.IndexPath(cty.NumberIntVal(1)),
+					OldValue: cty.StringVal("B"),
+					NewValue: cty.StringVal("X"),
+				},
+			},
+			cty.TupleVal([]cty.Value{cty.StringVal("A"), cty.StringVal("B")}),
+			cty.TupleVal([]cty.Value{cty.StringVal("A"), cty.StringVal("X")}),
+		},
+
+		// Delete
+		{
+			"DeleteObject",
+			Diff{
+				DeleteChange{
+					Path:     cty.GetAttrPath("a"),
+					OldValue: cty.StringVal("A"),
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{"a": cty.StringVal("A"), "b": cty.StringVal("B")}),
+			cty.ObjectVal(map[string]cty.Value{"b": cty.StringVal("B")}),
+		},
+		{
+			"DeleteMap",
+			Diff{
+				DeleteChange{
+					Path:     cty.IndexPath(cty.StringVal("a")),
+					OldValue: cty.StringVal("A"),
+				},
+			},
+			cty.MapVal(map[string]cty.Value{"a": cty.StringVal("A"), "b": cty.StringVal("B")}),
+			cty.MapVal(map[string]cty.Value{"b": cty.StringVal("B")}),
+		},
+		{
+			"DeleteList",
+			Diff{
+				DeleteChange{
+					Path:     cty.IndexPath(cty.NumberIntVal(1)),
+					OldValue: cty.StringVal("B"),
+				},
+			},
+			cty.ListVal([]cty.Value{cty.StringVal("A"), cty.StringVal("B"), cty.StringVal("C")}),
+			cty.ListVal([]cty.Value{cty.StringVal("A"), cty.StringVal("C")}),
+		},
+		{
+			"DeleteTuple",
+			Diff{
+				DeleteChange{
+					Path:     cty.IndexPath(cty.NumberIntVal(0)),
+					OldValue: cty.StringVal("A"),
+				},
+			},
+			cty.TupleVal([]cty.Value{cty.StringVal("A"), cty.StringVal("B")}),
+			cty.TupleVal([]cty.Value{cty.StringVal("B")}),
+		},
+
+		// Insert
+		{
+			"InsertListEmpty",
+			Diff{
+				InsertChange{
+					Path:        nil,
+					NewValue:    cty.StringVal("a"),
+					BeforeValue: cty.NullVal(cty.String),
+				},
+			},
+			cty.ListValEmpty(cty.String),
+			cty.ListVal([]cty.Value{cty.StringVal("a")}),
+		},
+		{
+			"InsertList",
+			Diff{
+				InsertChange{
+					Path:        nil,
+					NewValue:    cty.StringVal("x"),
+					BeforeValue: cty.StringVal("a"),
+				},
+			},
+			cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b"), cty.StringVal("a")}),
+			cty.ListVal([]cty.Value{cty.StringVal("x"), cty.StringVal("a"), cty.StringVal("b"), cty.StringVal("a")}),
+		},
+		{
+			"InsertTupleEmpty",
+			Diff{
+				InsertChange{
+					Path:        nil,
+					NewValue:    cty.StringVal("a"),
+					BeforeValue: cty.NullVal(cty.String),
+				},
+			},
+			cty.TupleVal(nil),
+			cty.TupleVal([]cty.Value{cty.StringVal("a")}),
+		},
+		{
+			"InsertList",
+			Diff{
+				InsertChange{
+					Path:        nil,
+					NewValue:    cty.StringVal("x"),
+					BeforeValue: cty.StringVal("b"),
+				},
+			},
+			cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+			cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("x"), cty.StringVal("b")}),
+		},
+
+		// Add
+		{
+			"AddSet",
+			Diff{
+				AddChange{
+					Path:     nil,
+					NewValue: cty.StringVal("a"),
+				},
+			},
+			cty.SetValEmpty(cty.String),
+			cty.SetVal([]cty.Value{cty.StringVal("a")}),
+		},
+
+		// Remove
+		{
+			"RemoveSet",
+			Diff{
+				RemoveChange{
+					Path:     nil,
+					OldValue: cty.StringVal("a"),
+				},
+			},
+			cty.SetVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+			cty.SetVal([]cty.Value{cty.StringVal("b")}),
+		},
+
+		// Context
+		{
+			"Context",
+			Diff{
+				Context{
+					Path:      cty.GetAttrPath("a"),
+					WantValue: cty.StringVal("A"),
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{"a": cty.StringVal("A")}),
+			cty.ObjectVal(map[string]cty.Value{"a": cty.StringVal("A")}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.diff.Apply(tt.source)
+			if err != nil {
+				t.Fatalf("Apply() err = %v", err)
+			}
+			if !got.RawEquals(tt.want) {
+				t.Errorf("Apply\nGot\n%#v\nWant\n%#v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently `diff.Apply` returns an error `not yet implemented`.

The comment https://github.com/zclconf/go-cty/pull/18#issuecomment-485941933 states _"This diff package is, to be honest, kinda abandoned at this point"_ but it is more focused on the diff printing aspect, rather than applying a diff to update values. I have a use-case for applying changes to a `cty.Value` and the diff package fits the bill perfectly. As the code is 2 years old, i'm not expecting it to be implemented any time soon, if at all.

This PR implements [`diff.Apply()`](https://github.com/zclconf/go-cty/blob/4fecf87372ec204b46eb9e8ff264cdc3cafdccfe/cty/diff/diff.go#L39-L41), and i think it is _(mostly)_ correct. The implementation adds an `apply` method on the [`Change interface`](https://github.com/zclconf/go-cty/blob/4fecf87372ec204b46eb9e8ff264cdc3cafdccfe/cty/diff/change.go#L12) and this method is added to the various `xxxChange` types. I'm sure i missed something so i would really like another pair of eyes on it. :eyes:

This PR only includes tests for the happy path. I'd like to get some input before cleaning it up. The existing [`diff.NewDiff()`](https://github.com/zclconf/go-cty/blob/4fecf87372ec204b46eb9e8ff264cdc3cafdccfe/cty/diff/diff.go#L32-L34) panics but that is not included in this PR.

_If the diff should not be implemented, I think it would be good to remove the package so people don't get their hopes up from godoc, as it currently isn't functional anyway._