### PR TITLE
[WIP] Unify dynamic with object or tuple types

### DIFF
--- a/cty/convert/unify_test.go
+++ b/cty/convert/unify_test.go
@@ -114,6 +114,24 @@ func TestUnify(t *testing.T) {
 			[]cty.Type{
 				cty.Tuple([]cty.Type{cty.String}),
 				cty.Tuple([]cty.Type{cty.Number}),
+				cty.DynamicPseudoType,
+			},
+			cty.Tuple([]cty.Type{cty.String}),
+			[]bool{false, true, true},
+		},
+		{
+			[]cty.Type{
+				cty.DynamicPseudoType,
+				cty.Tuple([]cty.Type{cty.String}),
+				cty.Tuple([]cty.Type{cty.Number}),
+			},
+			cty.Tuple([]cty.Type{cty.String}),
+			[]bool{true, false, true},
+		},
+		{
+			[]cty.Type{
+				cty.Tuple([]cty.Type{cty.String}),
+				cty.Tuple([]cty.Type{cty.Number}),
 			},
 			cty.Tuple([]cty.Type{cty.String}),
 			[]bool{false, true},
@@ -147,16 +165,34 @@ func TestUnify(t *testing.T) {
 				cty.DynamicPseudoType,
 				cty.Tuple([]cty.Type{cty.Number}),
 			},
-			cty.DynamicPseudoType,
-			[]bool{true, true},
+			cty.Tuple([]cty.Type{cty.Number}),
+			[]bool{true, false},
 		},
 		{
 			[]cty.Type{
 				cty.DynamicPseudoType,
 				cty.Object(map[string]cty.Type{"num": cty.Number}),
 			},
-			cty.DynamicPseudoType,
-			[]bool{true, true},
+			cty.Object(map[string]cty.Type{"num": cty.Number}),
+			[]bool{true, false},
+		},
+		{
+			[]cty.Type{
+				cty.Tuple([]cty.Type{cty.Number}),
+				cty.DynamicPseudoType,
+				cty.Tuple([]cty.Type{cty.Number}),
+			},
+			cty.Tuple([]cty.Type{cty.Number}),
+			[]bool{false, true, false},
+		},
+		{
+			[]cty.Type{
+				cty.DynamicPseudoType,
+				cty.Object(map[string]cty.Type{"num": cty.Number}),
+				cty.DynamicPseudoType,
+			},
+			cty.Object(map[string]cty.Type{"num": cty.Number}),
+			[]bool{true, false, true},
 		},
 		{
 			[]cty.Type{


### PR DESCRIPTION
Unify already will return a primitive type when a dynamic type exists in
the list. When presented with objects or tuples however, the behavior
was to default to DynamicPseudoType. The most common example
where this is evident, is in conditional expressions with a `null` that
always return a DynamicPseudoType.

This changes the behavior so that dynamic types will be speculatively
converted to the returned unified type, when a single type can be found
for a tuple or object.

This seems correct, since it follows the behavior of primitive types, though
there are statistically more combinations of types the dynamic value could
resolve to which would make the predicted type incorrect or invalid.