### PR TITLE
Safe conversion from Bool to Number

### DIFF
--- a/cty/convert/conversion_primitive.go
+++ b/cty/convert/conversion_primitive.go
@@ -20,16 +20,14 @@ var primitiveConversionsSafe = map[cty.Type]map[cty.Type]conversion{
 		cty.String: func(val cty.Value, path cty.Path) (cty.Value, error) {
 			if val.True() {
 				return stringTrue, nil
-			} else {
-				return stringFalse, nil
 			}
+			return stringFalse, nil
 		},
 		cty.Number: func(val cty.Value, path cty.Path) (cty.Value, error) {
 			if val.True() {
 				return numberTrue, nil
-			} else {
-				return numberFalse, nil
 			}
+			return numberFalse, nil
 		},
 	},
 }

--- a/cty/convert/conversion_primitive.go
+++ b/cty/convert/conversion_primitive.go
@@ -6,6 +6,8 @@ import (
 
 var stringTrue = cty.StringVal("true")
 var stringFalse = cty.StringVal("false")
+var numberTrue = cty.NumberIntVal(1)
+var numberFalse = cty.NumberIntVal(0)
 
 var primitiveConversionsSafe = map[cty.Type]map[cty.Type]conversion{
 	cty.Number: {
@@ -20,6 +22,13 @@ var primitiveConversionsSafe = map[cty.Type]map[cty.Type]conversion{
 				return stringTrue, nil
 			} else {
 				return stringFalse, nil
+			}
+		},
+		cty.Number: func(val cty.Value, path cty.Path) (cty.Value, error) {
+			if val.True() {
+				return numberTrue, nil
+			} else {
+				return numberFalse, nil
 			}
 		},
 	},

--- a/cty/convert/public_test.go
+++ b/cty/convert/public_test.go
@@ -80,6 +80,16 @@ func TestConvert(t *testing.T) {
 			Want:  cty.StringVal("false"),
 		},
 		{
+			Value: cty.True,
+			Type:  cty.Number,
+			Want:  cty.NumberIntVal(1),
+		},
+		{
+			Value: cty.False,
+			Type:  cty.Number,
+			Want:  cty.NumberIntVal(0),
+		},
+		{
 			Value: cty.UnknownVal(cty.String),
 			Type:  cty.Number,
 			Want:  cty.UnknownVal(cty.Number),
@@ -321,7 +331,11 @@ func TestConvert(t *testing.T) {
 				"bool": cty.True,
 			}),
 			Type:      cty.Map(cty.DynamicPseudoType),
-			WantError: true, // no common base type to unify to
+			WantError: false,
+			Want: cty.MapVal(map[string]cty.Value{
+				"num":  cty.NumberIntVal(5),
+				"bool": cty.NumberIntVal(1),
+			}),
 		},
 		{
 			Value: cty.MapVal(map[string]cty.Value{
@@ -436,7 +450,10 @@ func TestConvert(t *testing.T) {
 			Type: cty.Object(map[string]cty.Type{
 				"foo": cty.Number,
 			}),
-			WantError: true, // recursive conversion from bool to number is impossible
+			WantError: false,
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.NumberIntVal(1),
+			}),
 		},
 		{
 			Value: cty.ObjectVal(map[string]cty.Value{
@@ -445,7 +462,10 @@ func TestConvert(t *testing.T) {
 			Type: cty.Object(map[string]cty.Type{
 				"foo": cty.Number,
 			}),
-			WantError: true, // recursive conversion from bool to number is impossible
+			WantError: false,
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.UnknownVal(cty.Number),
+			}),
 		},
 		{
 			Value: cty.NullVal(cty.String),

--- a/cty/convert/unify_test.go
+++ b/cty/convert/unify_test.go
@@ -51,8 +51,13 @@ func TestUnify(t *testing.T) {
 		},
 		{
 			[]cty.Type{cty.Bool, cty.Number},
-			cty.NilType,
-			nil,
+			cty.Number,
+			[]bool{true, false},
+		},
+		{
+			[]cty.Type{cty.Number, cty.Bool},
+			cty.Number,
+			[]bool{false, true},
 		},
 		{
 			[]cty.Type{
@@ -91,16 +96,16 @@ func TestUnify(t *testing.T) {
 				cty.Object(map[string]cty.Type{"foo": cty.Bool}),
 				cty.Object(map[string]cty.Type{"bar": cty.Number}),
 			},
-			cty.NilType,
-			nil,
+			cty.Map(cty.Number),
+			[]bool{true, true},
 		},
 		{
 			[]cty.Type{
 				cty.Object(map[string]cty.Type{"foo": cty.Bool}),
 				cty.Object(map[string]cty.Type{"foo": cty.Number}),
 			},
-			cty.NilType,
-			nil,
+			cty.Object(map[string]cty.Type{"foo": cty.Number}),
+			[]bool{true, false},
 		},
 		{
 			[]cty.Type{
@@ -139,8 +144,8 @@ func TestUnify(t *testing.T) {
 				cty.Tuple([]cty.Type{cty.Bool}),
 				cty.Tuple([]cty.Type{cty.Number}),
 			},
-			cty.NilType,
-			nil,
+			cty.Tuple([]cty.Type{cty.Number}),
+			[]bool{true, false},
 		},
 		{
 			[]cty.Type{

--- a/cty/function/stdlib/format_test.go
+++ b/cty/function/stdlib/format_test.go
@@ -313,7 +313,7 @@ func TestFormat(t *testing.T) {
 			``,
 		},
 		{
-			cty.StringVal("%d green bottles standing on the wall xxx"),
+			cty.StringVal("%d green bottles standing on the wall"),
 			[]cty.Value{cty.True},
 			cty.StringVal("1 green bottles standing on the wall"),
 			``,

--- a/cty/function/stdlib/format_test.go
+++ b/cty/function/stdlib/format_test.go
@@ -313,10 +313,10 @@ func TestFormat(t *testing.T) {
 			``,
 		},
 		{
-			cty.StringVal("%d green bottles standing on the wall"),
+			cty.StringVal("%d green bottles standing on the wall xxx"),
 			[]cty.Value{cty.True},
-			cty.NilVal,
-			`unsupported value for "%d" at 0: number required`,
+			cty.StringVal("1 green bottles standing on the wall"),
+			``,
 		},
 		{
 			cty.StringVal("%b"),

--- a/docs/convert.md
+++ b/docs/convert.md
@@ -110,10 +110,10 @@ other two primitive types have safe conversions to string. The full
 matrix for primitive types is as follows:
 
 |         | string | number | boolean |
-|---------|:------:|:------:|:-------:|
-| string  |   n/a  | unsafe |  unsafe |
-| number  |  safe  |   n/a  |   none  |
-| boolean |  safe  |  none  |   n/a   |
+| ------- | :----: | :----: | :-----: |
+| string  |  n/a   | unsafe | unsafe  |
+| number  |  safe  |  n/a   |  none   |
+| boolean |  safe  |  safe  |   n/a   |
 
 The conversions for compound types are then derived from the above foundation.
 For example, a list of numbers can convert to a list of strings
@@ -121,13 +121,13 @@ because a number can convert to a string.
 
 The compound type kinds themselves have some available conversions, though:
 
-|        |  tuple | object | list |   map  |     set    |
-|--------|:------:|:------:|:----:|:------:|:----------:|
-| tuple  |   n/a  |  none  | safe |  none  | safe+lossy |
-| object |  none  |   n/a  | none |  safe  |    none    |
-| list   | unsafe |  none  |  n/a |  none  | safe+lossy |
-| map    |  none  | unsafe | none |   n/a  |    none    |
-| set    | unsafe |  none  | safe |  none  |     n/a    |
+|        | tuple  | object | list  |  map  |    set     |
+| ------ | :----: | :----: | :---: | :---: | :--------: |
+| tuple  |  n/a   |  none  | safe  | none  | safe+lossy |
+| object |  none  |  n/a   | none  | safe  |    none    |
+| list   | unsafe |  none  |  n/a  | none  | safe+lossy |
+| map    |  none  | unsafe | none  |  n/a  |    none    |
+| set    | unsafe |  none  | safe  | none  |    n/a     |
 
 Conversions between compound kinds, as shown above, are possible only
 if their respective elements/attributes also have conversions available.


### PR DESCRIPTION
Hi, 

Here is a proposal to add bool to number conversion as safe operation: 
`true` -> 1
`false` -> 0

The need behind this PR is to propagate this behavior to Terraform and have `count` parameter accepting booleans.  

I haven't coded num->bool conversion as IMO it requires more discussion about what can be considered as `true` in a number : Only 1 ? Any positive number ? What about negative numbers ? 
