### PR TITLE
SetVal: Fix stack overflow in umarking logic

### DIFF
--- a/cty/marks.go
+++ b/cty/marks.go
@@ -200,7 +200,7 @@ func (val Value) Unmark() (Value, ValueMarks) {
 func (val Value) UnmarkDeep() (Value, ValueMarks) {
 	marks := make(ValueMarks)
 	ret, _ := Transform(val, func(_ Path, v Value) (Value, error) {
-		unmarkedV, valueMarks := val.Unmark()
+		unmarkedV, valueMarks := v.Unmark()
 		for m, s := range valueMarks {
 			marks[m] = s
 		}

--- a/cty/value_init_test.go
+++ b/cty/value_init_test.go
@@ -1,6 +1,7 @@
 package cty
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -27,5 +28,91 @@ func TestSetVal(t *testing.T) {
 
 	if got, want := deepMarked.unmarkForce(), SetVal([]Value{True}); !got.RawEquals(want) {
 		t.Errorf("wrong unmarked value for deepMarked\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestSetVal_nestedStructures(t *testing.T) {
+	testCases := []struct {
+		Name  string
+		Elems []Value
+	}{
+		{
+			"set",
+			[]Value{
+				SetVal([]Value{
+					NumberIntVal(5),
+				}),
+			},
+		},
+		{
+			"doubly nested set",
+			[]Value{
+				SetVal([]Value{
+					SetVal([]Value{
+						NumberIntVal(5),
+					}),
+				}),
+			},
+		},
+		{
+			"list",
+			[]Value{
+				ListVal([]Value{
+					NumberIntVal(5),
+				}),
+			},
+		},
+		{
+			"doubly nested list",
+			[]Value{
+				ListVal([]Value{
+					ListVal([]Value{
+						NumberIntVal(5),
+					}),
+				}),
+			},
+		},
+		{
+			"map",
+			[]Value{
+				MapVal(map[string]Value{
+					"key": NumberIntVal(5),
+				}),
+			},
+		},
+		{
+			"doubly nested map",
+			[]Value{
+				MapVal(map[string]Value{
+					"key": MapVal(map[string]Value{
+						"child": StringVal("hello world"),
+					}),
+				}),
+			},
+		},
+		{
+			"tuple",
+			[]Value{
+				TupleVal([]Value{
+					NumberIntVal(5),
+				}),
+			},
+		},
+		{
+			"doubly nested tuple",
+			[]Value{
+				TupleVal([]Value{
+					TupleVal([]Value{
+						NumberIntVal(5),
+					}),
+				}),
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
+			SetVal(tc.Elems)
+		})
 	}
 }

--- a/cty/walk_test.go
+++ b/cty/walk_test.go
@@ -101,11 +101,11 @@ func TestTransform(t *testing.T) {
 		"unknown_map":  UnknownVal(Map(Bool)),
 	})
 
-	gotVal, err := Transform(val, func(path Path, val Value) (Value, error) {
-		if val.Type().IsPrimitiveType() {
+	gotVal, err := Transform(val, func(path Path, v Value) (Value, error) {
+		if v.Type().IsPrimitiveType() {
 			return StringVal(fmt.Sprintf("%#v", path)), nil
 		}
-		return val, nil
+		return v, nil
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)


### PR DESCRIPTION
This fixes the following stack overflow as demonstrated in the attached test.

```
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow

runtime stack:
runtime.throw(0x12c7621, 0xe)
	/Users/radeksimko/.goenv/versions/1.12.9/src/runtime/panic.go:617 +0x72
runtime.newstack()
	/Users/radeksimko/.goenv/versions/1.12.9/src/runtime/stack.go:1041 +0x6f0
runtime.morestack()
	/Users/radeksimko/.goenv/versions/1.12.9/src/runtime/asm_amd64.s:429 +0x8f

...
```