### PR TITLE
add conversion for map to object

### DIFF
--- a/cty/convert/conversion.go
+++ b/cty/convert/conversion.go
@@ -138,6 +138,9 @@ func getConversionKnown(in cty.Type, out cty.Type, unsafe bool) conversion {
 		outEty := out.ElementType()
 		return conversionObjectToMap(in, outEty, unsafe)
 
+	case out.IsObjectType() && in.IsMapType():
+		return conversionMapToObject(in, out, unsafe)
+
 	case in.IsCapsuleType() || out.IsCapsuleType():
 		if !unsafe {
 			// Capsule types can only participate in "unsafe" conversions,

--- a/cty/convert/public_test.go
+++ b/cty/convert/public_test.go
@@ -336,6 +336,41 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			Value: cty.MapVal(map[string]cty.Value{
+				"greeting": cty.StringVal("Hello"),
+				"name":     cty.StringVal("John"),
+			}),
+			Type: cty.Object(map[string]cty.Type{
+				"greeting": cty.String,
+				"name":     cty.String,
+			}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"greeting": cty.StringVal("Hello"),
+				"name":     cty.StringVal("John"),
+			}),
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"greeting": cty.StringVal("Hello"),
+				"name":     cty.StringVal("John"),
+			}),
+			Type: cty.Object(map[string]cty.Type{
+				"greeting": cty.List(cty.String),
+				"name":     cty.String,
+			}),
+			WantError: true, // "greeting" cannot be converted
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"greeting": cty.StringVal("Hello"),
+				"name":     cty.StringVal("John"),
+			}),
+			Type: cty.Object(map[string]cty.Type{
+				"name": cty.String,
+			}),
+			WantError: true, // object has no attribute "greeting"
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
 				"a": cty.NumberIntVal(2),
 				"b": cty.NumberIntVal(5),
 			}),


### PR DESCRIPTION
Allow conversions from maps to objects.

We return a conversion when the map element type can convert to all
possible attributes. The conversion itself will fail if the map contains
keys that are not valid attributes of that object type.