### PR TITLE
Support conversions from Map to Object (#39)

### DIFF
--- a/cty/convert/conversion.go
+++ b/cty/convert/conversion.go
@@ -138,6 +138,14 @@ func getConversionKnown(in cty.Type, out cty.Type, unsafe bool) conversion {
 		outEty := out.ElementType()
 		return conversionObjectToMap(in, outEty, unsafe)
 
+	case out.IsObjectType() && in.IsMapType():
+		if !unsafe {
+			// Conversion from map to object is unsafe because we don't know
+			// at this point if the map has all the keys the object wants.
+			return nil
+		}
+		return conversionMapToObject(in, out, unsafe)
+
 	case in.IsCapsuleType() || out.IsCapsuleType():
 		if !unsafe {
 			// Capsule types can only participate in "unsafe" conversions,

--- a/cty/convert/public_test.go
+++ b/cty/convert/public_test.go
@@ -448,6 +448,108 @@ func TestConvert(t *testing.T) {
 			WantError: true, // recursive conversion from bool to number is impossible
 		},
 		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"foo": cty.StringVal("foo value"),
+				"bar": cty.StringVal("bar value"),
+			}),
+			Type: cty.Object(map[string]cty.Type{
+				"foo": cty.String,
+			}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.StringVal("foo value"),
+			}),
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"foo": cty.True,
+			}),
+			Type: cty.Object(map[string]cty.Type{
+				"foo": cty.String,
+			}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.StringVal("true"),
+			}),
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"foo": cty.DynamicVal,
+			}),
+			Type: cty.Object(map[string]cty.Type{
+				"foo": cty.String,
+			}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.UnknownVal(cty.String),
+			}),
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"foo": cty.NullVal(cty.String),
+			}),
+			Type: cty.Object(map[string]cty.Type{
+				"foo": cty.String,
+			}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.NullVal(cty.String),
+			}),
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"foo": cty.True,
+			}),
+			Type: cty.Object(map[string]cty.Type{
+				"foo": cty.DynamicPseudoType,
+			}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.True,
+			}),
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"bar": cty.StringVal("bar value"),
+			}),
+			Type: cty.Object(map[string]cty.Type{
+				"foo": cty.String,
+			}),
+			WantError: true, // given value must have superset object type
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"bar": cty.StringVal("bar value"),
+			}),
+			Type: cty.Object(map[string]cty.Type{
+				"foo": cty.String,
+				"baz": cty.String,
+			}),
+			WantError: true, // given value must have superset object type
+		},
+		{
+			Value: cty.MapValEmpty(cty.String),
+			Type: cty.Object(map[string]cty.Type{
+				"foo": cty.String,
+				"bar": cty.String,
+				"baz": cty.String,
+			}),
+			WantError: true, // given value must have superset object type
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"foo": cty.True,
+			}),
+			Type: cty.Object(map[string]cty.Type{
+				"foo": cty.Number,
+			}),
+			WantError: true, // recursive conversion from bool to number is impossible
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"foo": cty.UnknownVal(cty.Bool),
+			}),
+			Type: cty.Object(map[string]cty.Type{
+				"foo": cty.Number,
+			}),
+			WantError: true, // recursive conversion from bool to number is impossible
+		},
+		{
 			Value: cty.NullVal(cty.String),
 			Type:  cty.DynamicPseudoType,
 			Want:  cty.NullVal(cty.String),
@@ -538,6 +640,22 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			Value: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.StringVal("hello"),
+				"bar": cty.StringVal("world").Mark(1),
+			}),
+			Type: cty.Object(map[string]cty.Type{"foo": cty.String}),
+			Want: cty.ObjectVal(map[string]cty.Value{"foo": cty.StringVal("hello")}),
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"foo": cty.StringVal("hello").Mark(1),
+				"bar": cty.StringVal("world").Mark(1),
+			}),
+			Type: cty.Object(map[string]cty.Type{"foo": cty.String}),
+			Want: cty.ObjectVal(map[string]cty.Value{"foo": cty.StringVal("hello").Mark(1)}),
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
 				"foo": cty.StringVal("hello"),
 				"bar": cty.StringVal("world").Mark(1),
 			}),


### PR DESCRIPTION
Converting from a `Map` to an `Object` seems to be substantially the same as converting from an `Object`. The only difference is that converting from a `Map` must be unsafe as we don’t know if it has all of the necessary keys until we try to do the conversion.

I attempted to share as much of `conversionObjectToObject` as possible, then duplicated all of the `Object`-to-`Object` tests as `Map`-to-`Object`.

This is my first time writing go so please let me know if I haven’t done things in the idiomatic way, or have missed some potential pitfall.

Fixes #39.