### PR TITLE
add conversion for map to object

### DIFF
--- a/cty/convert/conversion.go
+++ b/cty/convert/conversion.go
@@ -138,6 +138,15 @@ func getConversionKnown(in cty.Type, out cty.Type, unsafe bool) conversion {
 		outEty := out.ElementType()
 		return conversionObjectToMap(in, outEty, unsafe)
 
+	case out.IsObjectType() && in.IsMapType():
+		if !unsafe {
+			// Converting a map to an object is an "unsafe" conversion,
+			// because we don't know if all the map keys will correspond to
+			// object attributes.
+			return nil
+		}
+		return conversionMapToObject(in, out, unsafe)
+
 	case in.IsCapsuleType() || out.IsCapsuleType():
 		if !unsafe {
 			// Capsule types can only participate in "unsafe" conversions,

--- a/cty/convert/conversion_collection.go
+++ b/cty/convert/conversion_collection.go
@@ -338,3 +338,63 @@ func conversionObjectToMap(objectType cty.Type, mapEty cty.Type, unsafe bool) co
 		return cty.MapVal(elems), nil
 	}
 }
+
+// conversionMapToObject returns a conversion that will take a value of the
+// given map type and return an object of the given type. The object attribute
+// types must all be compatible with the map element type.
+//
+// Will panic if the given mapType and objType are not maps and objects
+// respectively.
+func conversionMapToObject(mapType cty.Type, objType cty.Type, unsafe bool) conversion {
+	objectAtys := objType.AttributeTypes()
+	mapEty := mapType.ElementType()
+
+	elemConvs := make(map[string]conversion, len(objectAtys))
+	for name, objectAty := range objectAtys {
+		if objectAty.Equals(mapEty) {
+			// no conversion required
+			continue
+		}
+
+		elemConvs[name] = getConversion(mapEty, objectAty, unsafe)
+		if elemConvs[name] == nil {
+			// If any of our element conversions are impossible, then the our
+			// whole conversion is impossible.
+			return nil
+		}
+	}
+
+	// If we fall out here then a conversion is possible, using the
+	// element conversions in elemConvs
+	return func(val cty.Value, path cty.Path) (cty.Value, error) {
+		elems := make(map[string]cty.Value, len(elemConvs))
+		path = append(path, nil)
+		it := val.ElementIterator()
+		for it.Next() {
+			name, val := it.Element()
+
+			// if there is no corresponding attribute, we skip this key
+			if _, ok := objectAtys[name.AsString()]; !ok {
+				continue
+			}
+
+			var err error
+
+			path[len(path)-1] = cty.IndexStep{
+				Key: name,
+			}
+
+			conv := elemConvs[name.AsString()]
+			if conv != nil {
+				val, err = conv(val, path)
+				if err != nil {
+					return cty.NilVal, err
+				}
+			}
+
+			elems[name.AsString()] = val
+		}
+
+		return cty.ObjectVal(elems), nil
+	}
+}

--- a/cty/convert/public_test.go
+++ b/cty/convert/public_test.go
@@ -336,6 +336,43 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			Value: cty.MapVal(map[string]cty.Value{
+				"greeting": cty.StringVal("Hello"),
+				"name":     cty.StringVal("John"),
+			}),
+			Type: cty.Object(map[string]cty.Type{
+				"greeting": cty.String,
+				"name":     cty.String,
+			}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"greeting": cty.StringVal("Hello"),
+				"name":     cty.StringVal("John"),
+			}),
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"greeting": cty.StringVal("Hello"),
+				"name":     cty.StringVal("John"),
+			}),
+			Type: cty.Object(map[string]cty.Type{
+				"greeting": cty.List(cty.String),
+				"name":     cty.String,
+			}),
+			WantError: true, // "greeting" cannot be converted
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"greeting": cty.StringVal("Hello"),
+				"name":     cty.StringVal("John"),
+			}),
+			Type: cty.Object(map[string]cty.Type{
+				"name": cty.String,
+			}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"name": cty.StringVal("John"),
+			}),
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
 				"a": cty.NumberIntVal(2),
 				"b": cty.NumberIntVal(5),
 			}),


### PR DESCRIPTION
Allow conversions from maps to objects.

We return a conversion when the map element type con convert to all
possible attributes. The conversion itself will fail if the map contains
keys that are not valid attributes of that object type.