### PR TITLE
prevent a panic in cty.Type.Equals(Type) when t.typeImpl is nil

### DIFF
--- a/cty/object_type_test.go
+++ b/cty/object_type_test.go
@@ -12,6 +12,11 @@ func TestObjectTypeEquals(t *testing.T) {
 		Expected bool
 	}{
 		{
+			NilType,
+			String,
+			false,
+		},
+		{
 			Object(map[string]Type{}),
 			Object(map[string]Type{}),
 			true,

--- a/cty/type.go
+++ b/cty/type.go
@@ -36,7 +36,7 @@ func (t typeImplSigil) isTypeImpl() typeImplSigil {
 // Equals returns true if the other given Type exactly equals the receiver
 // type.
 func (t Type) Equals(other Type) bool {
-	return t.typeImpl.Equals(other)
+	return t.typeImpl != nil && t.typeImpl.Equals(other)
 }
 
 // FriendlyName returns a human-friendly *English* name for the given type.


### PR DESCRIPTION
Hello there this closes #43.

~I'm looking for an acceptable place to tests this.~ found one