### PR TITLE
Fix Substr function call with length argument of zero to return ""

### DIFF
--- a/cty/function/stdlib/string.go
+++ b/cty/function/stdlib/string.go
@@ -144,7 +144,13 @@ var SubstrFunc = function.New(&function.Spec{
 			}
 
 			offset += totalLen
+		} else if length == 0 {
+			// Short circuit here, after error checks, because if a
+			// string of length 0 has been requested it will always
+			// be the empty string
+			return cty.StringVal(""), nil
 		}
+
 
 		sub := in
 		pos := 0

--- a/cty/function/stdlib/string_test.go
+++ b/cty/function/stdlib/string_test.go
@@ -324,6 +324,12 @@ func TestSubstr(t *testing.T) {
 			cty.StringVal(""),
 		},
 		{
+			cty.StringVal("hello"),
+			cty.NumberIntVal(0),
+			cty.NumberIntVal(0),
+			cty.StringVal(""),
+		},
+		{
 			cty.StringVal("noël"),
 			cty.NumberIntVal(0),
 			cty.NumberIntVal(3),


### PR DESCRIPTION
This issue was raised in terraform (hashicorp/terraform#24318) and it looks like it's a bug in `stdlib.SubstrFunc`'s impl where the substr function returns the whole string then the `length` argument is 0.

I've got a fix which is hopefully useful, I thought that it'd be best to have the `length` check as high up as it can but there may be other factors I'm not considering (I've run the test suite and it's passing).