### PR TITLE
Add additional path convenience methods

### DIFF
--- a/cty/path.go
+++ b/cty/path.go
@@ -51,9 +51,29 @@ func (p Path) Index(v Value) Path {
 	return ret
 }
 
+// IndexInt is a typed convenience method for Index.
+func (p Path) IndexInt(v int) Path {
+	return p.Index(NumberIntVal(int64(v)))
+}
+
+// IndexString is a typed convenience method for Index.
+func (p Path) IndexString(v string) Path {
+	return p.Index(StringVal(v))
+}
+
 // IndexPath is a convenience method to start a new Path with an IndexStep.
 func IndexPath(v Value) Path {
 	return Path{}.Index(v)
+}
+
+// IndexIntPath is a typed convenience method for IndexPath.
+func IndexIntPath(v int) Path {
+	return IndexPath(NumberIntVal(int64(v)))
+}
+
+// IndexStringPath is a typed convenience method for IndexPath.
+func IndexStringPath(v string) Path {
+	return IndexPath(StringVal(v))
 }
 
 // GetAttr returns a new Path that is the reciever with a GetAttrStep appended

--- a/cty/path_test.go
+++ b/cty/path_test.go
@@ -242,6 +242,58 @@ func TestPathEquals(t *testing.T) {
 				cty.GetAttrStep{Name: "attr"},
 			},
 		},
+
+		// tests for convenience methods
+		{
+			A: cty.Path{
+				cty.GetAttrStep{Name: "attr"},
+			},
+			B:      cty.GetAttrPath("attr"),
+			Prefix: true,
+			Equal:  true,
+		},
+		{
+			A: cty.Path{
+				cty.IndexStep{Key: cty.NumberIntVal(0)},
+			},
+			B:      cty.IndexPath(cty.NumberIntVal(0)),
+			Prefix: true,
+			Equal:  true,
+		},
+		{
+			A: cty.Path{
+				cty.IndexStep{Key: cty.NumberIntVal(0)},
+			},
+			B:      cty.IndexIntPath(0),
+			Prefix: true,
+			Equal:  true,
+		},
+		{
+			A: cty.Path{
+				cty.IndexStep{Key: cty.StringVal("key")},
+			},
+			B:      cty.IndexStringPath("key"),
+			Prefix: true,
+			Equal:  true,
+		},
+		{
+			A: cty.Path{
+				cty.GetAttrStep{Name: "attr"},
+				cty.IndexStep{Key: cty.NumberIntVal(0)},
+			},
+			B:      cty.GetAttrPath("attr").IndexInt(0),
+			Prefix: true,
+			Equal:  true,
+		},
+		{
+			A: cty.Path{
+				cty.GetAttrStep{Name: "attr"},
+				cty.IndexStep{Key: cty.StringVal("key")},
+			},
+			B:      cty.GetAttrPath("attr").IndexString("key"),
+			Prefix: true,
+			Equal:  true,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Add `int`/`string` helpers to the Index path convenience methods.

It would be kinda breaking, but may also be nice to change all of the convenience methods to be variadic? Maybe that's just overkill, UX wise you are probably only dealing with 1-2 depth at a time.