### PR TITLE
function/stdlib: Preserve infinity for floor/ceil

### DIFF
--- a/cty/function/stdlib/number.go
+++ b/cty/function/stdlib/number.go
@@ -375,6 +375,9 @@ var CeilFunc = function.New(&function.Spec{
 		if err := gocty.FromCtyValue(args[0], &val); err != nil {
 			return cty.UnknownVal(cty.String), err
 		}
+		if math.IsInf(val, 0) {
+			return cty.NumberFloatVal(val), nil
+		}
 		return cty.NumberIntVal(int64(math.Ceil(val))), nil
 	},
 })
@@ -393,6 +396,9 @@ var FloorFunc = function.New(&function.Spec{
 		var val float64
 		if err := gocty.FromCtyValue(args[0], &val); err != nil {
 			return cty.UnknownVal(cty.String), err
+		}
+		if math.IsInf(val, 0) {
+			return cty.NumberFloatVal(val), nil
 		}
 		return cty.NumberIntVal(int64(math.Floor(val))), nil
 	},

--- a/cty/function/stdlib/number_test.go
+++ b/cty/function/stdlib/number_test.go
@@ -2,6 +2,7 @@ package stdlib
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"testing"
 
@@ -806,6 +807,16 @@ func TestCeil(t *testing.T) {
 			cty.NumberFloatVal(2),
 			false,
 		},
+		{
+			cty.NumberFloatVal(math.Inf(1)),
+			cty.NumberFloatVal(math.Inf(1)),
+			false,
+		},
+		{
+			cty.NumberFloatVal(math.Inf(-1)),
+			cty.NumberFloatVal(math.Inf(-1)),
+			false,
+		},
 	}
 
 	for _, test := range tests {
@@ -842,6 +853,16 @@ func TestFloor(t *testing.T) {
 		{
 			cty.NumberFloatVal(1.2),
 			cty.NumberFloatVal(1),
+			false,
+		},
+		{
+			cty.NumberFloatVal(math.Inf(1)),
+			cty.NumberFloatVal(math.Inf(1)),
+			false,
+		},
+		{
+			cty.NumberFloatVal(math.Inf(-1)),
+			cty.NumberFloatVal(math.Inf(-1)),
 			false,
 		},
 	}


### PR DESCRIPTION
`floor(±infinity)` and `ceil(±infinity)` would previously return the max/min limit of `int64`. This could lead to confusing behaviour. Instead, we want to pass through the infinite value without converting to integer.

From https://github.com/hashicorp/terraform/issues/21463