### PR TITLE
Fix set function unification

### DIFF
--- a/cty/function/stdlib/set_test.go
+++ b/cty/function/stdlib/set_test.go
@@ -55,6 +55,27 @@ func TestSetUnion(t *testing.T) {
 				cty.StringVal("c"),
 			}),
 		},
+		{
+			[]cty.Value{
+				cty.SetVal([]cty.Value{cty.True}),
+				cty.SetValEmpty(cty.DynamicPseudoType),
+			},
+			cty.SetVal([]cty.Value{cty.True}),
+		},
+		{
+			[]cty.Value{
+				cty.SetVal([]cty.Value{cty.EmptyObjectVal}),
+				cty.SetValEmpty(cty.DynamicPseudoType),
+			},
+			cty.SetVal([]cty.Value{cty.EmptyObjectVal}),
+		},
+		{
+			[]cty.Value{
+				cty.SetValEmpty(cty.DynamicPseudoType),
+				cty.SetValEmpty(cty.DynamicPseudoType),
+			},
+			cty.SetValEmpty(cty.DynamicPseudoType),
+		},
 	}
 
 	for _, test := range tests {
@@ -117,6 +138,27 @@ func TestSetIntersection(t *testing.T) {
 				cty.StringVal("b"),
 			}),
 		},
+		{
+			[]cty.Value{
+				cty.SetVal([]cty.Value{cty.True}),
+				cty.SetValEmpty(cty.DynamicPseudoType),
+			},
+			cty.SetValEmpty(cty.Bool),
+		},
+		{
+			[]cty.Value{
+				cty.SetVal([]cty.Value{cty.EmptyObjectVal}),
+				cty.SetValEmpty(cty.DynamicPseudoType),
+			},
+			cty.SetValEmpty(cty.EmptyObject),
+		},
+		{
+			[]cty.Value{
+				cty.SetValEmpty(cty.DynamicPseudoType),
+				cty.SetValEmpty(cty.DynamicPseudoType),
+			},
+			cty.SetValEmpty(cty.DynamicPseudoType),
+		},
 	}
 
 	for _, test := range tests {
@@ -168,6 +210,21 @@ func TestSetSubtract(t *testing.T) {
 			cty.SetVal([]cty.Value{
 				cty.StringVal("b"),
 			}),
+		},
+		{
+			cty.SetVal([]cty.Value{cty.StringVal("a")}),
+			cty.SetValEmpty(cty.DynamicPseudoType),
+			cty.SetVal([]cty.Value{cty.StringVal("a")}),
+		},
+		{
+			cty.SetVal([]cty.Value{cty.EmptyObjectVal}),
+			cty.SetValEmpty(cty.DynamicPseudoType),
+			cty.SetVal([]cty.Value{cty.EmptyObjectVal}),
+		},
+		{
+			cty.SetValEmpty(cty.DynamicPseudoType),
+			cty.SetValEmpty(cty.DynamicPseudoType),
+			cty.SetValEmpty(cty.DynamicPseudoType),
 		},
 	}
 

--- a/cty/gocty/in_test.go
+++ b/cty/gocty/in_test.go
@@ -480,6 +480,10 @@ func (r testSetRules) Equivalent(v1 interface{}, v2 interface{}) bool {
 	return v1 == v2
 }
 
+func (r testSetRules) SameRules(other set.Rules) bool {
+	return r == other
+}
+
 type capsuleType1Native struct {
 	name string
 }

--- a/cty/path_set.go
+++ b/cty/path_set.go
@@ -196,3 +196,9 @@ func (r pathSetRules) Equivalent(a, b interface{}) bool {
 
 	return true
 }
+
+// SameRules is true if both Rules instances are pathSetRules structs.
+func (r pathSetRules) SameRules(other set.Rules) bool {
+	_, ok := other.(pathSetRules)
+	return ok
+}

--- a/cty/set/rules.go
+++ b/cty/set/rules.go
@@ -22,6 +22,10 @@ type Rules interface {
 	// though it is *not* required that two values with the same hash value
 	// be equivalent.
 	Equivalent(interface{}, interface{}) bool
+
+	// SameRules returns true if the instance is equivalent to another Rules
+	// instance.
+	SameRules(Rules) bool
 }
 
 // OrderedRules is an extension of Rules that can apply a partial order to

--- a/cty/set/rules_test.go
+++ b/cty/set/rules_test.go
@@ -13,3 +13,7 @@ func (r testRules) Hash(val interface{}) int {
 func (r testRules) Equivalent(val1 interface{}, val2 interface{}) bool {
 	return val1 == val2
 }
+
+func (r testRules) SameRules(other Rules) bool {
+	return r == other // true if "other" is also a testRules
+}

--- a/cty/set/set.go
+++ b/cty/set/set.go
@@ -41,7 +41,7 @@ func NewSetFromSlice(rules Rules, vals []interface{}) Set {
 }
 
 func sameRules(s1 Set, s2 Set) bool {
-	return s1.rules == s2.rules
+	return s1.rules.SameRules(s2.rules)
 }
 
 func mustHaveSameRules(s1 Set, s2 Set) {
@@ -53,7 +53,7 @@ func mustHaveSameRules(s1 Set, s2 Set) {
 // HasRules returns true if and only if the receiving set has the given rules
 // instance as its rules.
 func (s Set) HasRules(rules Rules) bool {
-	return s.rules == rules
+	return s.rules.SameRules(rules)
 }
 
 // Rules returns the receiving set's rules instance.

--- a/cty/set_internals.go
+++ b/cty/set_internals.go
@@ -65,6 +65,17 @@ func (r setRules) Equivalent(v1 interface{}, v2 interface{}) bool {
 	return eqv.v == true
 }
 
+// SameRules is only true if the other Rules instance is also a setRules struct,
+// and the types are considered equal.
+func (r setRules) SameRules(other set.Rules) bool {
+	rules, ok := other.(setRules)
+	if !ok {
+		return false
+	}
+
+	return r.Type.Equals(rules.Type)
+}
+
 // Less is an implementation of set.OrderedRules so that we can iterate over
 // set elements in a consistent order, where such an order is possible.
 func (r setRules) Less(v1, v2 interface{}) bool {

--- a/cty/set_internals_test.go
+++ b/cty/set_internals_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math/big"
 	"testing"
+
+	"github.com/zclconf/go-cty/cty/set"
 )
 
 func TestSetHashBytes(t *testing.T) {
@@ -309,6 +311,59 @@ func TestSetOrder(t *testing.T) {
 			got := rules.Less(test.a.v, test.b.v)
 			if got != test.want {
 				t.Errorf("wrong result\na: %#v\nb: %#v\ngot:  %#v\nwant: %#v", test.a, test.b, got, test.want)
+			}
+		})
+	}
+}
+
+func TestSetRulesSameRules(t *testing.T) {
+	tests := []struct {
+		a    set.Rules
+		b    set.Rules
+		want bool
+	}{
+		{
+			setRules{EmptyObject},
+			setRules{DynamicPseudoType},
+			false,
+		},
+		{
+			setRules{EmptyObject},
+			setRules{EmptyObject},
+			true,
+		},
+		{
+			setRules{String},
+			setRules{String},
+			true,
+		},
+		{
+			setRules{Object(map[string]Type{"a": String})},
+			setRules{Object(map[string]Type{"a": String})},
+			true,
+		},
+		{
+			setRules{Object(map[string]Type{"a": String})},
+			setRules{Object(map[string]Type{"a": Bool})},
+			false,
+		},
+		{
+			pathSetRules{},
+			pathSetRules{},
+			true,
+		},
+		{
+			setRules{DynamicPseudoType},
+			pathSetRules{},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%#v.SameRules(%#v)", test.a, test.b), func(t *testing.T) {
+			got := test.a.SameRules(test.b)
+			if got != test.want {
+				t.Errorf("wrong result\na: %#v\nb: %#v\ngot %#v, want %#v", test.a, test.b, got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
Two changes here to fix panics when using the `stdlib` set functions (`setintersect`, `setunion`, etc) where one of the parameters is an empty collection.

## Add Equals method to set.Rules

Previously, we checked if two sets had the same rules using a simple equality check. This panics if the sets contain object types, as they cannot be compared using `==`.

Adding an `Equals` method to the `Rules` interface allows us to delegate to the `Type.Equals` method where necessary, fixing this problem.

## Fix set function crashes with empty sets

If one or more arguments to the `stdlib` set functions was an empty set of dynamic pseudo type, the functions would panic due to incompatible set rules.

We can special case empty dynamic pseudo type sets to be ignored through type unification, because they are always capable of being converted to any other type.

## Downstream crash

This PR fixes this Terraform crash:

```
$ echo 'setsubtract([{}], [])' | tf console

Error: Error in function call

  on /Users/alisdair/code/terraform/main.tf line 2, in output "x":
   2:   value = setsubtract([{}], [])

Call to function "setsubtract" failed: panic in function implementation:
incompatible set rules: cty.setRules{Type:cty.EmptyObject},
cty.setRules{Type:cty.DynamicPseudoType}
```