### PR TITLE
Allow null values for jsonencode

### DIFF
--- a/cty/function/stdlib/json.go
+++ b/cty/function/stdlib/json.go
@@ -26,7 +26,7 @@ var JSONEncodeFunc = function.New(&function.Spec{
 		}
 
 		if val.IsNull() {
-			return cty.NullVal(retType), nil
+			return cty.StringVal("null"), nil
 		}
 
 		buf, err := json.Marshal(val, val.Type())

--- a/cty/function/stdlib/json.go
+++ b/cty/function/stdlib/json.go
@@ -12,6 +12,7 @@ var JSONEncodeFunc = function.New(&function.Spec{
 			Name:             "val",
 			Type:             cty.DynamicPseudoType,
 			AllowDynamicType: true,
+			AllowNull:        true,
 		},
 	},
 	Type: function.StaticReturnType(cty.String),
@@ -22,6 +23,10 @@ var JSONEncodeFunc = function.New(&function.Spec{
 			// contains any _nested_ unknowns then our result must be
 			// unknown.
 			return cty.UnknownVal(retType), nil
+		}
+
+		if val.IsNull() {
+			return cty.NullVal(retType), nil
 		}
 
 		buf, err := json.Marshal(val, val.Type())

--- a/cty/function/stdlib/json_test.go
+++ b/cty/function/stdlib/json_test.go
@@ -52,10 +52,9 @@ func TestJSONEncode(t *testing.T) {
 			cty.DynamicVal,
 			cty.UnknownVal(cty.String),
 		},
-		// We allow null values
 		{
 			cty.NullVal(cty.String),
-			cty.NullVal(cty.String),
+			cty.StringVal("null"),
 		},
 	}
 

--- a/cty/function/stdlib/json_test.go
+++ b/cty/function/stdlib/json_test.go
@@ -52,6 +52,11 @@ func TestJSONEncode(t *testing.T) {
 			cty.DynamicVal,
 			cty.UnknownVal(cty.String),
 		},
+		// We allow null values
+		{
+			cty.NullVal(cty.String),
+			cty.NullVal(cty.String),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This addresses https://github.com/hashicorp/terraform/issues/23062, where `jsonencode` does not allow null values, but it is documented in Terraform that it does: https://www.terraform.io/docs/configuration/functions/jsonencode.html. 

Terraform currently uses this zclconf edition of the go-cty library, but if this change is unwarranted here, perhaps it would be a better fit to migrate Terraform to https://github.com/hashicorp/go-cty and make changes there.