### PR TITLE
convert: Fix panic: heterogeneous tuple with null

### DIFF
--- a/cty/convert/public_test.go
+++ b/cty/convert/public_test.go
@@ -677,6 +677,95 @@ func TestConvert(t *testing.T) {
 			}),
 			WantError: false,
 		},
+		// https://github.com/hashicorp/terraform/issues/24377:
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("a")}),
+				cty.StringVal("b"),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			Type:      cty.Set(cty.DynamicPseudoType),
+			WantError: true,
+		},
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("a")}),
+				cty.StringVal("b"),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			Type:      cty.List(cty.DynamicPseudoType),
+			WantError: true,
+		},
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("a")}),
+				cty.StringVal("b"),
+			}),
+			Type:      cty.Set(cty.DynamicPseudoType),
+			WantError: true,
+		},
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("a")}),
+				cty.StringVal("b"),
+			}),
+			Type:      cty.List(cty.DynamicPseudoType),
+			WantError: true,
+		},
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.StringVal("a"),
+				cty.NumberIntVal(9),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			Type: cty.Set(cty.DynamicPseudoType),
+			Want: cty.SetVal([]cty.Value{
+				cty.StringVal("a"),
+				cty.StringVal("9"),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			WantError: false,
+		},
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.StringVal("a"),
+				cty.NumberIntVal(9),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			Type: cty.List(cty.DynamicPseudoType),
+			Want: cty.ListVal([]cty.Value{
+				cty.StringVal("a"),
+				cty.StringVal("9"),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			WantError: false,
+		},
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.NullVal(cty.DynamicPseudoType),
+				cty.NullVal(cty.DynamicPseudoType),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			Type: cty.Set(cty.DynamicPseudoType),
+			Want: cty.SetVal([]cty.Value{
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			WantError: false,
+		},
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.NullVal(cty.DynamicPseudoType),
+				cty.NullVal(cty.DynamicPseudoType),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			Type: cty.List(cty.DynamicPseudoType),
+			Want: cty.ListVal([]cty.Value{
+				cty.NullVal(cty.DynamicPseudoType),
+				cty.NullVal(cty.DynamicPseudoType),
+				cty.NullVal(cty.DynamicPseudoType),
+			}),
+			WantError: false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Tuples with elements of different types can be converted to homogeneous collections (sets or lists), so long as their elements are unifiable. For example:

```hcl
toset(["a", "b"])     // all elements have the same type
toset(["a", 5])       // "a" and 5 can be unified to string
toset(["a", 5, null]) // null is a valid value for string
```

However, tuples with elements which are not unifiable cannot be converted to homogeneous collections:

```hcl
toset([["a"], "b"])   // no common type for list(string) and string
```

This commit fixes a panic for this failure case, when the tuple contains both non-unifiable types and a null value:

```hcl
toset([["a"], "b", null]) // should not panic
```

The null value was causing the unification process to result in a list or set of dynamic type, which causes the conversion functions to pass through the original value. This meant that in the final conversion step, we would attempt to construct a list or set of different values, which panics.

Fixes hashicorp/terraform#24377