### PR TITLE
Allow empty maps to merge function

### DIFF
--- a/cty/function/stdlib/collection.go
+++ b/cty/function/stdlib/collection.go
@@ -762,6 +762,9 @@ var MergeFunc = function.New(&function.Spec{
 		case allNull:
 			return cty.NullVal(retType), nil
 		case retType.IsMapType():
+			if len(outputMap) == 0 {
+				return cty.MapValEmpty(retType.ElementType()), nil
+			}
 			return cty.MapVal(outputMap), nil
 		case retType.IsObjectType(), retType.Equals(cty.DynamicPseudoType):
 			return cty.ObjectVal(outputMap), nil

--- a/cty/function/stdlib/collection_test.go
+++ b/cty/function/stdlib/collection_test.go
@@ -506,6 +506,14 @@ func TestMerge(t *testing.T) {
 			cty.NilVal,
 			true,
 		},
+		{ // Empty maps are allowed in merge
+			[]cty.Value{
+				cty.MapValEmpty(cty.String),
+				cty.MapValEmpty(cty.String),
+			},
+			cty.MapValEmpty(cty.String),
+			false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Passing empty maps to MapVal panics. If we have an empty map after merging maps, return `MapValEmpty` so that we avoid this panic. Fixes https://github.com/hashicorp/terraform/issues/25303