### PR TITLE
function/stdlib: Fix panic with unknown set values

### DIFF
--- a/cty/function/stdlib/set.go
+++ b/cty/function/stdlib/set.go
@@ -167,7 +167,7 @@ func setOperationReturnType(args []cty.Value) (ret cty.Type, err error) {
 
 		// Do not unify types for empty dynamic pseudo typed collections. These
 		// will always convert to any other concrete type.
-		if arg.LengthInt() == 0 && ty.Equals(cty.DynamicPseudoType) {
+		if arg.IsKnown() && arg.LengthInt() == 0 && ty.Equals(cty.DynamicPseudoType) {
 			continue
 		}
 

--- a/cty/function/stdlib/set_test.go
+++ b/cty/function/stdlib/set_test.go
@@ -76,6 +76,13 @@ func TestSetUnion(t *testing.T) {
 			},
 			cty.SetValEmpty(cty.DynamicPseudoType),
 		},
+		{
+			[]cty.Value{
+				cty.SetVal([]cty.Value{cty.StringVal("5")}),
+				cty.UnknownVal(cty.Set(cty.Number)),
+			},
+			cty.UnknownVal(cty.Set(cty.String)),
+		},
 	}
 
 	for _, test := range tests {
@@ -159,6 +166,13 @@ func TestSetIntersection(t *testing.T) {
 			},
 			cty.SetValEmpty(cty.DynamicPseudoType),
 		},
+		{
+			[]cty.Value{
+				cty.SetVal([]cty.Value{cty.StringVal("5")}),
+				cty.UnknownVal(cty.Set(cty.Number)),
+			},
+			cty.UnknownVal(cty.Set(cty.String)),
+		},
 	}
 
 	for _, test := range tests {
@@ -225,6 +239,11 @@ func TestSetSubtract(t *testing.T) {
 			cty.SetValEmpty(cty.DynamicPseudoType),
 			cty.SetValEmpty(cty.DynamicPseudoType),
 			cty.SetValEmpty(cty.DynamicPseudoType),
+		},
+		{
+			cty.SetVal([]cty.Value{cty.StringVal("5")}),
+			cty.UnknownVal(cty.Set(cty.Number)),
+			cty.UnknownVal(cty.Set(cty.String)),
 		},
 	}
 


### PR DESCRIPTION
[The fix for set unification](https://github.com/zclconf/go-cty/pull/52/files) recently introduced a bug with unknown set values which would cause a panic (hashicorp/terraform#25318). This was triggered by calling `LengthInt` on an unknown collection.

This commit fixes this by first verifying that the argument is known, so that calling its length is safe. If the argument is not known, it could be of any length, so we do not want to omit its element type from the set to be unified.

Includes regression tests.

Fixes hashicorp/terraform#25318