### PR TITLE
Coalesce: treat empty string values like other null values

### DIFF
--- a/cty/function/stdlib/general.go
+++ b/cty/function/stdlib/general.go
@@ -82,6 +82,9 @@ var CoalesceFunc = function.New(&function.Spec{
 			if argVal.IsNull() {
 				continue
 			}
+			if retType == cty.String && argVal.RawEquals(cty.StringVal("")) {
+				continue
+			}
 
 			return convert.Convert(argVal, retType)
 		}

--- a/cty/function/stdlib/general_test.go
+++ b/cty/function/stdlib/general_test.go
@@ -88,6 +88,10 @@ func TestCoalesce(t *testing.T) {
 			cty.False,
 		},
 		{
+			[]cty.Value{cty.StringVal(""), cty.False, cty.StringVal("hello")},
+			cty.StringVal("false"),
+		},
+		{
 			[]cty.Value{cty.NullVal(cty.Bool), cty.False, cty.StringVal("hello")},
 			cty.StringVal("false"),
 		},


### PR DESCRIPTION
Before this change, coalesce used to treat empty strings as non null values and the empty string could be returned by coalesce.

This is most likely a breaking change and was done in Terraform here: https://github.com/hashicorp/terraform/commit/d4669246c7c74fa2a203718797167640c5701251 instead of the go-cty lib, I could not find the why exactly but I think this was done to avoid a breaking change. 
I would perfectly understand if this PR was not merged 🙂 , in which case I will probably open the same PR against hashicorp/go-cty-funcs.

I'm opening it here because I think this repo would be the best place to contain this.

Cheers !