### PR TITLE
funcs/element: fix panic when used with negative index

### DIFF
--- a/cty/function/stdlib/collection.go
+++ b/cty/function/stdlib/collection.go
@@ -138,6 +138,13 @@ var ElementFunc = function.New(&function.Spec{
 	},
 	Type: func(args []cty.Value) (cty.Type, error) {
 		list := args[0]
+		index := args[1]
+		if index.IsKnown() {
+			if index.LessThan(cty.NumberIntVal(0)).True() {
+				return cty.DynamicPseudoType, fmt.Errorf("cannot use element function with a negative index")
+			}
+		}
+
 		listTy := list.Type()
 		switch {
 		case listTy.IsListType():
@@ -171,6 +178,10 @@ var ElementFunc = function.New(&function.Spec{
 		if err != nil {
 			// can't happen because we checked this in the Type function above
 			return cty.DynamicVal, fmt.Errorf("invalid index: %s", err)
+		}
+
+		if args[1].LessThan(cty.NumberIntVal(0)).True() {
+			return cty.DynamicVal, fmt.Errorf("cannot use element function with a negative index")
 		}
 
 		if !args[0].IsKnown() {

--- a/cty/function/stdlib/collection_test.go
+++ b/cty/function/stdlib/collection_test.go
@@ -710,6 +710,25 @@ func TestLookup(t *testing.T) {
 }
 
 func TestElement(t *testing.T) {
+	listOfStrings := cty.ListVal([]cty.Value{
+		cty.StringVal("the"),
+		cty.StringVal("quick"),
+		cty.StringVal("brown"),
+		cty.StringVal("fox"),
+	})
+	listOfInts := cty.ListVal([]cty.Value{
+		cty.NumberIntVal(1),
+		cty.NumberIntVal(2),
+		cty.NumberIntVal(3),
+		cty.NumberIntVal(4),
+	})
+	listWithUnknown := cty.ListVal([]cty.Value{
+		cty.StringVal("the"),
+		cty.StringVal("quick"),
+		cty.StringVal("brown"),
+		cty.UnknownVal(cty.String),
+	})
+
 	tests := []struct {
 		List  cty.Value
 		Index cty.Value
@@ -717,34 +736,58 @@ func TestElement(t *testing.T) {
 		Err   bool
 	}{
 		{
-			cty.ListVal([]cty.Value{
-				cty.StringVal("foo"),
-				cty.StringVal("bar"),
-				cty.StringVal("baz"),
-			}),
+			listOfStrings,
 			cty.NumberIntVal(2),
-			cty.StringVal("baz"),
+			cty.StringVal("brown"),
 			false,
 		},
-		{
-			cty.ListVal([]cty.Value{
-				cty.StringVal("foo"),
-				cty.StringVal("bar"),
-				cty.StringVal("baz"),
-			}),
+		{ // index greater than length(list)
+			listOfStrings,
 			cty.NumberIntVal(5),
-			cty.StringVal("baz"),
+			cty.StringVal("quick"),
+			false,
+		},
+		{ // list of lists
+			cty.ListVal([]cty.Value{listOfStrings, listOfStrings}),
+			cty.NumberIntVal(0),
+			listOfStrings,
 			false,
 		},
 		{
-			cty.ListVal([]cty.Value{
-				cty.StringVal("foo"),
-				cty.StringVal("bar"),
-				cty.StringVal("baz"),
-			}),
+			listOfStrings,
+			cty.UnknownVal(cty.Number),
+			cty.UnknownVal(cty.String),
+			false,
+		},
+		{
+			listOfInts,
+			cty.NumberIntVal(2),
+			cty.NumberIntVal(3),
+			false,
+		},
+		{
+			listWithUnknown,
+			cty.NumberIntVal(2),
+			cty.StringVal("brown"),
+			false,
+		},
+		{
+			listWithUnknown,
+			cty.NumberIntVal(3),
+			cty.UnknownVal(cty.String),
+			false,
+		},
+		{
+			listOfStrings,
 			cty.NumberIntVal(-1),
 			cty.DynamicVal,
 			true, // index cannot be a negative number
+		},
+		{
+			listOfStrings,
+			cty.StringVal("brown"), // definitely not an index
+			cty.DynamicVal,
+			true,
 		},
 	}
 

--- a/cty/function/stdlib/collection_test.go
+++ b/cty/function/stdlib/collection_test.go
@@ -708,3 +708,62 @@ func TestLookup(t *testing.T) {
 		})
 	}
 }
+
+func TestElement(t *testing.T) {
+	tests := []struct {
+		List  cty.Value
+		Index cty.Value
+		Want  cty.Value
+		Err   bool
+	}{
+		{
+			cty.ListVal([]cty.Value{
+				cty.StringVal("foo"),
+				cty.StringVal("bar"),
+				cty.StringVal("baz"),
+			}),
+			cty.NumberIntVal(2),
+			cty.StringVal("baz"),
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{
+				cty.StringVal("foo"),
+				cty.StringVal("bar"),
+				cty.StringVal("baz"),
+			}),
+			cty.NumberIntVal(5),
+			cty.StringVal("baz"),
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{
+				cty.StringVal("foo"),
+				cty.StringVal("bar"),
+				cty.StringVal("baz"),
+			}),
+			cty.NumberIntVal(-1),
+			cty.DynamicVal,
+			true, // index cannot be a negative number
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Element(%#v,%#v)", test.List, test.Index), func(t *testing.T) {
+			got, err := Element(test.List, test.Index)
+
+			if test.Err {
+				if err == nil {
+					t.Fatal("succeeded; want error")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a check for a negative index to both Type Impl functions, and
some basic tests.

Downstream issue reference: https://github.com/hashicorp/terraform/issues/25775