### PR TITLE
build: remove go 1.11 and 1.12 from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.11.x
-  - 1.12.x
+  - 1.13.x
   - tip
 
 before_install:


### PR DESCRIPTION
Tests can't run on 1.11 and 1.12 (something something go modules) so I removed those and added a line for 1.13 (leaving `tip` in place for the next version of go).