### PR TITLE
Add Unmark utilities

### DIFF
--- a/cty/json/marshal.go
+++ b/cty/json/marshal.go
@@ -10,7 +10,7 @@ import (
 
 func marshal(val cty.Value, t cty.Type, path cty.Path, b *bytes.Buffer) error {
 	if val.IsMarked() {
-		return path.NewErrorf("value has marks, so it cannot be seralized")
+		return path.NewErrorf("value has marks, so it cannot be serialized as JSON")
 	}
 
 	// If we're going to decode as DynamicPseudoType then we need to save

--- a/cty/marks.go
+++ b/cty/marks.go
@@ -67,6 +67,23 @@ func (m ValueMarks) GoString() string {
 	return s.String()
 }
 
+// PathValueMarks is a structure that enables tracking marks
+// and the paths where they are located in one type
+type PathValueMarks struct {
+	Path  Path
+	Marks ValueMarks
+}
+
+func (p PathValueMarks) Equal(o PathValueMarks) bool {
+	if !p.Path.Equals(o.Path) {
+		return false
+	}
+	if !p.Marks.Equal(o.Marks) {
+		return false
+	}
+	return true
+}
+
 // IsMarked returns true if and only if the receiving value carries at least
 // one mark. A marked value cannot be used directly with integration methods
 // without explicitly unmarking it (and retrieving the markings) first.
@@ -203,6 +220,18 @@ func (val Value) UnmarkDeep() (Value, ValueMarks) {
 		unmarkedV, valueMarks := v.Unmark()
 		for m, s := range valueMarks {
 			marks[m] = s
+		}
+		return unmarkedV, nil
+	})
+	return ret, marks
+}
+
+func (val Value) UnmarkDeepWithPaths() (Value, []PathValueMarks) {
+	var marks []PathValueMarks
+	ret, _ := Transform(val, func(p Path, v Value) (Value, error) {
+		unmarkedV, valueMarks := v.Unmark()
+		if v.IsMarked() {
+			marks = append(marks, PathValueMarks{p, valueMarks})
 		}
 		return unmarkedV, nil
 	})

--- a/cty/marks.go
+++ b/cty/marks.go
@@ -192,7 +192,8 @@ func (val Value) Mark(mark interface{}) Value {
 }
 
 // MarkWithPaths accepts a slice of PathValueMarks to apply
-// marker particular paths
+// markers to particular paths and returns the marked
+// Value.
 func (val Value) MarkWithPaths(pvm []PathValueMarks) Value {
 	ret, _ := Transform(val, func(p Path, v Value) (Value, error) {
 		for _, path := range pvm {
@@ -240,6 +241,10 @@ func (val Value) UnmarkDeep() (Value, ValueMarks) {
 	return ret, marks
 }
 
+// UnmarkDeepWithPaths is like UnmarkDeep, except it returns a slice
+// of PathValueMarks rather than a superset of all marks. This allows
+// a caller to know which marks are associated with which paths
+// in the Value.
 func (val Value) UnmarkDeepWithPaths() (Value, []PathValueMarks) {
 	var marks []PathValueMarks
 	ret, _ := Transform(val, func(p Path, v Value) (Value, error) {

--- a/cty/marks.go
+++ b/cty/marks.go
@@ -191,6 +191,20 @@ func (val Value) Mark(mark interface{}) Value {
 	}
 }
 
+// MarkWithPaths accepts a slice of PathValueMarks to apply
+// marker particular paths
+func (val Value) MarkWithPaths(pvm []PathValueMarks) Value {
+	ret, _ := Transform(val, func(p Path, v Value) (Value, error) {
+		for _, path := range pvm {
+			if p.Equals(path.Path) {
+				return v.WithMarks(path.Marks), nil
+			}
+		}
+		return v, nil
+	})
+	return ret
+}
+
 // Unmark separates the marks of the receiving value from the value itself,
 // removing a new unmarked value and a map (representing a set) of the marks.
 //

--- a/cty/marks_test.go
+++ b/cty/marks_test.go
@@ -1,6 +1,7 @@
 package cty
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -68,6 +69,48 @@ func TestValueMarks(t *testing.T) {
 	remarked := unmarkedResult.MarkWithPaths(pvm)
 	if got, want := remarked, False.WithMarks(NewValueMarks("a", "b", "c", "d")); !want.RawEquals(got) {
 		t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestPathValueMarks(t *testing.T) {
+	tests := []struct {
+		original PathValueMarks
+		compare  PathValueMarks
+		want     bool
+	}{
+		{
+			PathValueMarks{Path{IndexStep{Key: NumberIntVal(0)}}, NewValueMarks("a")},
+			PathValueMarks{Path{IndexStep{Key: NumberIntVal(0)}}, NewValueMarks("a")},
+			true,
+		},
+		{
+			PathValueMarks{Path{IndexStep{Key: StringVal("p")}}, NewValueMarks(123)},
+			PathValueMarks{Path{IndexStep{Key: StringVal("p")}}, NewValueMarks(123)},
+			true,
+		},
+		{
+			PathValueMarks{Path{IndexStep{Key: NumberIntVal(0)}}, NewValueMarks("a")},
+			PathValueMarks{Path{IndexStep{Key: NumberIntVal(1)}}, NewValueMarks("a")},
+			false,
+		},
+		{
+			PathValueMarks{Path{IndexStep{Key: NumberIntVal(0)}}, NewValueMarks("a")},
+			PathValueMarks{Path{IndexStep{Key: NumberIntVal(0)}}, NewValueMarks("b")},
+			false,
+		},
+		{
+			PathValueMarks{Path{IndexStep{Key: NumberIntVal(0)}}, NewValueMarks("a")},
+			PathValueMarks{Path{IndexStep{Key: NumberIntVal(1)}}, NewValueMarks("b")},
+			false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Comparing %#v to %#v", test.original, test.compare), func(t *testing.T) {
+			got := test.original.Equal(test.compare)
+			if got != test.want {
+				t.Errorf("wrong result\ngot: %v\nwant: %v", got, test.want)
+			}
+		})
 	}
 }
 

--- a/cty/marks_test.go
+++ b/cty/marks_test.go
@@ -62,3 +62,23 @@ func TestValueMarks(t *testing.T) {
 		t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
 	}
 }
+
+func TestUnmarkDeep(t *testing.T) {
+	v := NumberIntVal(1).Mark("a")
+	v1 := NumberIntVal(2)
+	l := ListVal([]Value{v, v1})
+	if l.IsMarked() {
+		t.Error("Value containing marks should not be marked itself")
+	}
+	if !l.ContainsMarked() {
+		t.Error("Value containing marks should be caught by ContainsMarked")
+	}
+
+	l1, marks := l.UnmarkDeep()
+	if got, want := l1, ListVal([]Value{NumberIntVal(1), v1}); !want.RawEquals(got) {
+		t.Errorf("wrong result\ngot: #%v\nwant: %#v", got, want)
+	}
+	if got, want := marks, NewValueMarks("a"); !want.Equal(got) {
+		t.Errorf("wrong result\ngot: #%v\nwant: %#v", got, want)
+	}
+}

--- a/cty/marks_test.go
+++ b/cty/marks_test.go
@@ -81,4 +81,15 @@ func TestUnmarkDeep(t *testing.T) {
 	if got, want := marks, NewValueMarks("a"); !want.Equal(got) {
 		t.Errorf("wrong result\ngot: #%v\nwant: %#v", got, want)
 	}
+
+	l2, paths := l.UnmarkDeepWithPaths()
+	if got, want := l2, ListVal([]Value{NumberIntVal(1), v1}); !want.RawEquals(got) {
+		t.Errorf("wrong result\ngot: #%v\nwant: %#v", got, want)
+	}
+	expectedPathValueMarks := []PathValueMarks{{Path{IndexStep{Key: NumberIntVal(0)}}, NewValueMarks("a")}, {}, {}}
+	for i, p := range paths {
+		if got, want := p, expectedPathValueMarks[i]; !want.Equal(got) {
+			t.Errorf("wrong result\ngot: #%v\nwant: %#v", got, want)
+		}
+	}
 }

--- a/cty/marks_test.go
+++ b/cty/marks_test.go
@@ -61,6 +61,14 @@ func TestValueMarks(t *testing.T) {
 	if got, want := result, False.WithMarks(NewValueMarks("a", "b", "c", "d")); !want.RawEquals(got) {
 		t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
 	}
+
+	// Unmark the result and capture the paths
+	unmarkedResult, pvm := result.UnmarkDeepWithPaths()
+	// Remark the result with those paths
+	remarked := unmarkedResult.MarkWithPaths(pvm)
+	if got, want := remarked, False.WithMarks(NewValueMarks("a", "b", "c", "d")); !want.RawEquals(got) {
+		t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+	}
 }
 
 func TestUnmarkDeep(t *testing.T) {

--- a/cty/marks_test.go
+++ b/cty/marks_test.go
@@ -70,6 +70,12 @@ func TestValueMarks(t *testing.T) {
 	if got, want := remarked, False.WithMarks(NewValueMarks("a", "b", "c", "d")); !want.RawEquals(got) {
 		t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
 	}
+
+	// If we call MarkWithPaths without any matching paths, we should get the unmarked result
+	markedWithNoPaths := unmarkedResult.MarkWithPaths([]PathValueMarks{{Path{IndexStep{Key: NumberIntVal(0)}}, NewValueMarks("z")}})
+	if got, want := markedWithNoPaths, False; !want.RawEquals(got) {
+		t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+	}
 }
 
 func TestPathValueMarks(t *testing.T) {

--- a/cty/msgpack/marshal.go
+++ b/cty/msgpack/marshal.go
@@ -43,7 +43,7 @@ func Marshal(val cty.Value, ty cty.Type) ([]byte, error) {
 
 func marshal(val cty.Value, ty cty.Type, path cty.Path, enc *msgpack.Encoder) error {
 	if val.IsMarked() {
-		return path.NewErrorf("value has marks, so it cannot be seralized")
+		return path.NewErrorf("value has marks, so it cannot be serialized")
 	}
 
 	// If we're going to decode as DynamicPseudoType then we need to save


### PR DESCRIPTION
This PR adds two methods: `UnmarkDeepWithPaths`, `MarkWithPaths`, and the type `PathValueMarks` which is used in both methods. This allows a caller to call a method like Unmark, but instead of getting a superset of marks, get an array of marks and their associated paths. This allows for a Value to be unmarked and then remarked later.

Additional change: The error messages in `marshall` had a typo, and the JSON error was ambiguous, so the raised error would not make it clear that it was an error in JSON marshalling vs msgpack.