### PR TITLE
Fix deep marks functions with new transformer

### DIFF
--- a/cty/marks_test.go
+++ b/cty/marks_test.go
@@ -5,6 +5,101 @@ import (
 	"testing"
 )
 
+func TestContainsMarked(t *testing.T) {
+	testCases := []struct {
+		val  Value
+		want bool
+	}{
+		{
+			StringVal("a"),
+			false,
+		},
+		{
+			NumberIntVal(1).Mark("a"),
+			true,
+		},
+		{
+			ListVal([]Value{NumberIntVal(1), NumberIntVal(2)}),
+			false,
+		},
+		{
+			ListVal([]Value{NumberIntVal(1), NumberIntVal(2).Mark("a")}),
+			true,
+		},
+		{
+			ListVal([]Value{NumberIntVal(1), NumberIntVal(2)}).Mark("a"),
+			true,
+		},
+		{
+			ListValEmpty(String).Mark("c"),
+			true,
+		},
+		{
+			MapVal(map[string]Value{"a": StringVal("b").Mark("c"), "x": StringVal("y").Mark("z")}),
+			true,
+		},
+		{
+			TupleVal([]Value{NumberIntVal(1).Mark("a"), StringVal("y").Mark("z")}),
+			true,
+		},
+		{
+			SetVal([]Value{NumberIntVal(1).Mark("a"), NumberIntVal(2).Mark("z")}),
+			true,
+		},
+		{
+			ObjectVal(map[string]Value{
+				"x": ListVal([]Value{
+					NumberIntVal(1).Mark("a"),
+					NumberIntVal(2),
+				}),
+				"y": StringVal("y"),
+				"z": BoolVal(true),
+			}),
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		if got, want := tc.val.ContainsMarked(), tc.want; got != want {
+			t.Errorf("wrong result (got %v, want %v) for %#v", got, want, tc.val)
+		}
+	}
+}
+
+func TestIsMarked(t *testing.T) {
+	testCases := []struct {
+		val  Value
+		want bool
+	}{
+		{
+			StringVal("a"),
+			false,
+		},
+		{
+			NumberIntVal(1).Mark("a"),
+			true,
+		},
+		{
+			ListVal([]Value{NumberIntVal(1), NumberIntVal(2)}),
+			false,
+		},
+		{
+			ListVal([]Value{NumberIntVal(1), NumberIntVal(2).Mark("a")}),
+			false,
+		},
+		{
+			ListVal([]Value{NumberIntVal(1), NumberIntVal(2)}).Mark("a"),
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		if got, want := tc.val.IsMarked(), tc.want; got != want {
+			t.Errorf("wrong result (got %v, want %v) for %#v", got, want, tc.val)
+		}
+	}
+}
+
 func TestValueMarks(t *testing.T) {
 	v := True
 	v1 := v.Mark(1)
@@ -78,7 +173,7 @@ func TestValueMarks(t *testing.T) {
 	}
 }
 
-func TestPathValueMarks(t *testing.T) {
+func TestPathValueMarksEqual(t *testing.T) {
 	tests := []struct {
 		original PathValueMarks
 		compare  PathValueMarks
@@ -120,33 +215,242 @@ func TestPathValueMarks(t *testing.T) {
 	}
 }
 
-func TestUnmarkDeep(t *testing.T) {
-	v := NumberIntVal(1).Mark("a")
-	v1 := NumberIntVal(2)
-	l := ListVal([]Value{v, v1})
-	if l.IsMarked() {
-		t.Error("Value containing marks should not be marked itself")
-	}
-	if !l.ContainsMarked() {
-		t.Error("Value containing marks should be caught by ContainsMarked")
-	}
-
-	l1, marks := l.UnmarkDeep()
-	if got, want := l1, ListVal([]Value{NumberIntVal(1), v1}); !want.RawEquals(got) {
-		t.Errorf("wrong result\ngot: #%v\nwant: %#v", got, want)
-	}
-	if got, want := marks, NewValueMarks("a"); !want.Equal(got) {
-		t.Errorf("wrong result\ngot: #%v\nwant: %#v", got, want)
-	}
-
-	l2, paths := l.UnmarkDeepWithPaths()
-	if got, want := l2, ListVal([]Value{NumberIntVal(1), v1}); !want.RawEquals(got) {
-		t.Errorf("wrong result\ngot: #%v\nwant: %#v", got, want)
-	}
-	expectedPathValueMarks := []PathValueMarks{{Path{IndexStep{Key: NumberIntVal(0)}}, NewValueMarks("a")}, {}, {}}
-	for i, p := range paths {
-		if got, want := p, expectedPathValueMarks[i]; !want.Equal(got) {
-			t.Errorf("wrong result\ngot: #%v\nwant: %#v", got, want)
+func TestMarks(t *testing.T) {
+	wantMarks := func(marks ValueMarks, expected ...string) {
+		if len(marks) != len(expected) {
+			t.Fatalf("wrong marks: %#v", marks)
 		}
+		for _, mark := range expected {
+			if _, ok := marks[mark]; !ok {
+				t.Fatalf("missing mark %q: %#v", mark, marks)
+			}
+		}
+	}
+
+	// Single mark
+	val := StringVal("foo").Mark("a")
+	wantMarks(val.Marks(), "a")
+	val, marks := val.Unmark()
+	if val.IsMarked() {
+		t.Fatalf("still marked after unmark: %#v", marks)
+	}
+	wantMarks(marks, "a")
+
+	// Multiple marks
+	val = val.WithMarks(NewValueMarks("a", "b", "c"))
+	wantMarks(val.Marks(), "a", "b", "c")
+	val, marks = val.Unmark()
+	if val.IsMarked() {
+		t.Fatalf("still marked after unmark: %#v", marks)
+	}
+	wantMarks(marks, "a", "b", "c")
+}
+
+func TestUnmarkDeep(t *testing.T) {
+	testCases := map[string]struct {
+		val   Value
+		want  Value
+		marks ValueMarks
+	}{
+		"unmarked string": {
+			StringVal("a"),
+			StringVal("a"),
+			NewValueMarks(),
+		},
+		"marked number": {
+			NumberIntVal(1).Mark("a"),
+			NumberIntVal(1),
+			NewValueMarks("a"),
+		},
+		"unmarked list": {
+			ListVal([]Value{NumberIntVal(1), NumberIntVal(2)}),
+			ListVal([]Value{NumberIntVal(1), NumberIntVal(2)}),
+			NewValueMarks(),
+		},
+		"list with some elements marked": {
+			ListVal([]Value{NumberIntVal(1).Mark("a"), NumberIntVal(2)}),
+			ListVal([]Value{NumberIntVal(1), NumberIntVal(2)}),
+			NewValueMarks("a"),
+		},
+		"marked list with all elements marked": {
+			ListVal([]Value{NumberIntVal(1).Mark("a"), NumberIntVal(2).Mark("b")}).Mark("c"),
+			ListVal([]Value{NumberIntVal(1), NumberIntVal(2)}),
+			NewValueMarks("a", "b", "c"),
+		},
+		"marked empty list": {
+			ListValEmpty(String).Mark("c"),
+			ListValEmpty(String),
+			NewValueMarks("c"),
+		},
+		"map with elements marked": {
+			MapVal(map[string]Value{"a": StringVal("b").Mark("c"), "x": StringVal("y").Mark("z")}),
+			MapVal(map[string]Value{"a": StringVal("b"), "x": StringVal("y")}),
+			NewValueMarks("c", "z"),
+		},
+		"tuple with elements marked": {
+			TupleVal([]Value{NumberIntVal(1).Mark("a"), StringVal("y").Mark("z")}),
+			TupleVal([]Value{NumberIntVal(1), StringVal("y")}),
+			NewValueMarks("a", "z"),
+		},
+		"set with elements marked": {
+			SetVal([]Value{NumberIntVal(1).Mark("a"), NumberIntVal(2).Mark("z")}),
+			SetVal([]Value{NumberIntVal(1), NumberIntVal(2)}),
+			NewValueMarks("a", "z"),
+		},
+		"complex marked object with lots of marks": {
+			ObjectVal(map[string]Value{
+				"x": ListVal([]Value{
+					NumberIntVal(3).Mark("a"),
+					NumberIntVal(5).Mark("b"),
+				}).WithMarks(NewValueMarks("c", "d")),
+				"y": StringVal("y").Mark("e"),
+				"z": BoolVal(true).Mark("f"),
+			}).Mark("g"),
+			ObjectVal(map[string]Value{
+				"x": ListVal([]Value{
+					NumberIntVal(3),
+					NumberIntVal(5),
+				}),
+				"y": StringVal("y"),
+				"z": BoolVal(true),
+			}),
+			NewValueMarks("a", "b", "c", "d", "e", "f", "g"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, marks := tc.val.UnmarkDeep()
+			if !got.RawEquals(tc.want) {
+				t.Errorf("wrong value\n got: %#v\nwant: %#v", got, tc.want)
+			}
+			if !marks.Equal(tc.marks) {
+				t.Errorf("wrong marks\n got: %#v\nwant: %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPathValueMarks(t *testing.T) {
+	testCases := map[string]struct {
+		marked   Value
+		unmarked Value
+		pvms     []PathValueMarks
+	}{
+		"unmarked string": {
+			StringVal("a"),
+			StringVal("a"),
+			nil,
+		},
+		"marked number": {
+			NumberIntVal(1).Mark("a"),
+			NumberIntVal(1),
+			[]PathValueMarks{
+				{Path{}, NewValueMarks("a")},
+			},
+		},
+		"list with some elements marked": {
+			ListVal([]Value{NumberIntVal(1).Mark("a"), NumberIntVal(2)}),
+			ListVal([]Value{NumberIntVal(1), NumberIntVal(2)}),
+			[]PathValueMarks{
+				{IndexIntPath(0), NewValueMarks("a")},
+			},
+		},
+		"marked list with all elements marked": {
+			ListVal([]Value{NumberIntVal(1).Mark("a"), NumberIntVal(2).Mark("b")}).Mark("c"),
+			ListVal([]Value{NumberIntVal(1), NumberIntVal(2)}),
+			[]PathValueMarks{
+				{Path{}, NewValueMarks("c")},
+				{IndexIntPath(0), NewValueMarks("a")},
+				{IndexIntPath(1), NewValueMarks("b")},
+			},
+		},
+		"marked empty list": {
+			ListValEmpty(String).Mark("c"),
+			ListValEmpty(String),
+			[]PathValueMarks{
+				{Path{}, NewValueMarks("c")},
+			},
+		},
+		"map with elements marked": {
+			MapVal(map[string]Value{"a": StringVal("b").Mark("c"), "x": StringVal("y").Mark("z")}),
+			MapVal(map[string]Value{"a": StringVal("b"), "x": StringVal("y")}),
+			[]PathValueMarks{
+				{IndexStringPath("a"), NewValueMarks("c")},
+				{IndexStringPath("x"), NewValueMarks("z")},
+			},
+		},
+		"tuple with elements marked": {
+			TupleVal([]Value{NumberIntVal(1).Mark("a"), StringVal("y").Mark("z"), ObjectVal(map[string]Value{"x": True}).Mark("o")}),
+			TupleVal([]Value{NumberIntVal(1), StringVal("y"), ObjectVal(map[string]Value{"x": True})}),
+			[]PathValueMarks{
+				{IndexIntPath(0), NewValueMarks("a")},
+				{IndexIntPath(1), NewValueMarks("z")},
+				{IndexIntPath(2), NewValueMarks("o")},
+			},
+		},
+		"set with elements marked": {
+			SetVal([]Value{NumberIntVal(1).Mark("a"), NumberIntVal(2).Mark("z")}),
+			SetVal([]Value{NumberIntVal(1), NumberIntVal(2)}),
+			[]PathValueMarks{
+				{Path{}, NewValueMarks("a", "z")},
+			},
+		},
+		"complex marked object with lots of marks": {
+			ObjectVal(map[string]Value{
+				"x": ListVal([]Value{
+					NumberIntVal(3).Mark("a"),
+					NumberIntVal(5).Mark("b"),
+				}).WithMarks(NewValueMarks("c", "d")),
+				"y": StringVal("y").Mark("e"),
+				"z": BoolVal(true).Mark("f"),
+			}).Mark("g"),
+			ObjectVal(map[string]Value{
+				"x": ListVal([]Value{
+					NumberIntVal(3),
+					NumberIntVal(5),
+				}),
+				"y": StringVal("y"),
+				"z": BoolVal(true),
+			}),
+			[]PathValueMarks{
+				{Path{}, NewValueMarks("g")},
+				{GetAttrPath("x"), NewValueMarks("c", "d")},
+				{GetAttrPath("x").IndexInt(0), NewValueMarks("a")},
+				{GetAttrPath("x").IndexInt(1), NewValueMarks("b")},
+				{GetAttrPath("y"), NewValueMarks("e")},
+				{GetAttrPath("z"), NewValueMarks("f")},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(fmt.Sprintf("unmark: %s", name), func(t *testing.T) {
+			got, pvms := tc.marked.UnmarkDeepWithPaths()
+			if !got.RawEquals(tc.unmarked) {
+				t.Errorf("wrong value\n got: %#v\nwant: %#v", got, tc.unmarked)
+			}
+
+			if len(pvms) != len(tc.pvms) {
+				t.Errorf("wrong length\n got: %d\nwant: %d", len(pvms), len(tc.pvms))
+			}
+
+		findPvm:
+			for _, wantPvm := range tc.pvms {
+				for _, gotPvm := range pvms {
+					if gotPvm.Path.Equals(wantPvm.Path) && gotPvm.Marks.Equal(wantPvm.Marks) {
+						continue findPvm
+					}
+				}
+				t.Errorf("missing %#v\nnot found in: %#v", wantPvm, pvms)
+			}
+		})
+
+		t.Run(fmt.Sprintf("mark: %s", name), func(t *testing.T) {
+			got := tc.unmarked.MarkWithPaths(tc.pvms)
+			if !got.RawEquals(tc.marked) {
+				t.Errorf("wrong value\n got: %#v\nwant: %#v", got, tc.marked)
+			}
+		})
 	}
 }

--- a/cty/value_init.go
+++ b/cty/value_init.go
@@ -247,11 +247,6 @@ func SetVal(vals []Value) Value {
 			val = unmarkedVal
 			markSets = append(markSets, marks)
 		}
-		if val.ContainsMarked() {
-			// FIXME: Allow this, but unmark the values and apply the
-			// marking to the set itself instead.
-			panic("set cannot contain marked values")
-		}
 		if elementType == DynamicPseudoType {
 			elementType = val.ty
 		} else if val.ty != DynamicPseudoType && !elementType.Equals(val.ty) {

--- a/cty/walk.go
+++ b/cty/walk.go
@@ -61,6 +61,31 @@ func walk(path Path, val Value, cb func(Path, Value) (bool, error)) error {
 	return nil
 }
 
+// Transformer is the interface used to optionally transform values in a
+// possibly-complex structure. The Enter method is called before traversing
+// through a given path, and the Exit method is called when traversal of a
+// path is complete.
+//
+// Use Enter when you want to transform a complex value before traversal
+// (preorder), and Exit when you want to transform a value after traversal
+// (postorder).
+type Transformer interface {
+	Enter(Path, Value) (Value, error)
+	Exit(Path, Value) (Value, error)
+}
+
+type postorderTransformer struct {
+	callback func(Path, Value) (Value, error)
+}
+
+func (t *postorderTransformer) Enter(p Path, v Value) (Value, error) {
+	return v, nil
+}
+
+func (t *postorderTransformer) Exit(p Path, v Value) (Value, error) {
+	return t.callback(p, v)
+}
+
 // Transform visits all of the values in a possibly-complex structure,
 // calling a given function for each value which has an opportunity to
 // replace that value.
@@ -77,7 +102,7 @@ func walk(path Path, val Value, cb func(Path, Value) (bool, error)) error {
 // value constructor functions. An easy way to preserve invariants is to
 // ensure that the transform function never changes the value type.
 //
-// The callback function my halt the walk altogether by
+// The callback function may halt the walk altogether by
 // returning a non-nil error. If the returned error is about the element
 // currently being visited, it is recommended to use the provided path
 // value to produce a PathError describing that context.
@@ -86,10 +111,23 @@ func walk(path Path, val Value, cb func(Path, Value) (bool, error)) error {
 // returns, since its backing array is re-used for other calls.
 func Transform(val Value, cb func(Path, Value) (Value, error)) (Value, error) {
 	var path Path
-	return transform(path, val, cb)
+	return transform(path, val, &postorderTransformer{cb})
 }
 
-func transform(path Path, val Value, cb func(Path, Value) (Value, error)) (Value, error) {
+// TransformWithTransformer allows the caller to more closely control the
+// traversal used for transformation. See the documentation for Transformer for
+// more details.
+func TransformWithTransformer(val Value, t Transformer) (Value, error) {
+	var path Path
+	return transform(path, val, t)
+}
+
+func transform(path Path, val Value, t Transformer) (Value, error) {
+	val, err := t.Enter(path, val)
+	if err != nil {
+		return DynamicVal, err
+	}
+
 	ty := val.Type()
 	var newVal Value
 
@@ -112,7 +150,7 @@ func transform(path Path, val Value, cb func(Path, Value) (Value, error)) (Value
 				path := append(path, IndexStep{
 					Key: kv,
 				})
-				newEv, err := transform(path, ev, cb)
+				newEv, err := transform(path, ev, t)
 				if err != nil {
 					return DynamicVal, err
 				}
@@ -143,7 +181,7 @@ func transform(path Path, val Value, cb func(Path, Value) (Value, error)) (Value
 				path := append(path, IndexStep{
 					Key: kv,
 				})
-				newEv, err := transform(path, ev, cb)
+				newEv, err := transform(path, ev, t)
 				if err != nil {
 					return DynamicVal, err
 				}
@@ -165,7 +203,7 @@ func transform(path Path, val Value, cb func(Path, Value) (Value, error)) (Value
 				path := append(path, GetAttrStep{
 					Name: name,
 				})
-				newAV, err := transform(path, av, cb)
+				newAV, err := transform(path, av, t)
 				if err != nil {
 					return DynamicVal, err
 				}
@@ -178,5 +216,9 @@ func transform(path Path, val Value, cb func(Path, Value) (Value, error)) (Value
 		newVal = val
 	}
 
-	return cb(path, newVal)
+	newVal, err = t.Exit(path, newVal)
+	if err != nil {
+		return DynamicVal, err
+	}
+	return newVal, err
 }


### PR DESCRIPTION
The `UnmarkDeep`, `UnmarkDeepWithPaths`, and `MarkWithPaths` functions could previously panic with nested complex values. This was due to the `Transform` callback function only being called as part of a postorder traversal, when it is not permitted to traverse a marked value.

This commit introduces a new `TransformWithTransformer` function, requiring an implementation of a new `Transformer` interface. Using this interface, callers can implement either preorder or postorder traversals.

In turn, this allows us to write deep transformation for marks which successfully cope with all nested structures.

The commit includes significantly more tests for these functions, which should now cover all complex value types.