### PR TITLE
cty: Add WithMarksDeep

### DIFF
--- a/cty/marks.go
+++ b/cty/marks.go
@@ -364,3 +364,13 @@ func (val Value) WithSameMarks(srcs ...Value) Value {
 		},
 	}
 }
+
+// WithMarksDeep is similar to WithMarks, but it works with an entire nested
+// structure rather than just the given value directly.
+func (val Value) WithMarksDeep(marks ...ValueMarks) Value {
+	ret, _ := Transform(val, func(p Path, v Value) (Value, error) {
+		return v.WithMarks(marks...), nil
+	})
+
+	return ret
+}


### PR DESCRIPTION
This is to `WithMarks` as `UnmarkDeep` is to `Unmark`. When applying marks to nested values, it can be useful to recursively apply marks to the entire tree. Consider a "tainted" mark applied to a complex object value: carrying this through to every leaf value ensures that no "tainted" values leak as the object is traversed.

CC @pselle 