### PR TITLE
Ensure splitDateFormat() does not try to look for more bytes when we are at EOF

### DIFF
--- a/cty/function/stdlib/datetime.go
+++ b/cty/function/stdlib/datetime.go
@@ -362,9 +362,14 @@ func splitDateFormat(data []byte, atEOF bool) (advance int, token []byte, err er
 		for i := 1; i < len(data); i++ {
 			if data[i] == esc {
 				if (i + 1) == len(data) {
-					// We need at least one more byte to decide if this is an
-					// escape or a terminator.
-					return 0, nil, nil
+					if atEOF {
+						// We have a closing quote and are at the end of our input
+						return len(data), data, nil
+					} else {
+						// We need at least one more byte to decide if this is an
+						// escape or a terminator.
+						return 0, nil, nil
+					}
 				}
 				if data[i+1] == esc {
 					i++ // doubled-up quotes are an escape sequence

--- a/cty/function/stdlib/datetime_test.go
+++ b/cty/function/stdlib/datetime_test.go
@@ -40,6 +40,11 @@ func TestFormatDate(t *testing.T) {
 			``,
 		},
 		{
+			cty.StringVal("H 'o''clock'"),
+			cty.StringVal("3 o'clock"),
+			``,
+		},
+		{
 			cty.StringVal("hh:mm:ssZZZZ"),
 			cty.StringVal("15:04:05+0000"),
 			``,


### PR DESCRIPTION
Fixes Terraform bug https://github.com/hashicorp/terraform/issues/26356
I haven't raised a corresponding issue here, it just seemed like duplication of effort - hope that's ok.

It's end of day here and I'm AFK tomorrow so if there are any issues or changes requested I will be able to look on Friday.