### PR TITLE
function: Join lists with marked values

### DIFF
--- a/cty/function/stdlib/string.go
+++ b/cty/function/stdlib/string.go
@@ -151,7 +151,6 @@ var SubstrFunc = function.New(&function.Spec{
 			return cty.StringVal(""), nil
 		}
 
-
 		sub := in
 		pos := 0
 		var i int
@@ -225,10 +224,15 @@ var JoinFunc = function.New(&function.Spec{
 		}
 
 		items := make([]string, 0, l)
+		marks := make(cty.ValueMarks)
 		for ai, list := range listVals {
 			ei := 0
 			for it := list.ElementIterator(); it.Next(); {
 				_, val := it.Element()
+				val, valMarks := val.Unmark()
+				for k, s := range valMarks {
+					marks[k] = s
+				}
 				if val.IsNull() {
 					if len(listVals) > 1 {
 						return cty.UnknownVal(cty.String), function.NewArgErrorf(ai+1, "element %d of list %d is null; cannot concatenate null values", ei, ai+1)
@@ -240,7 +244,7 @@ var JoinFunc = function.New(&function.Spec{
 			}
 		}
 
-		return cty.StringVal(strings.Join(items, sep)), nil
+		return cty.StringVal(strings.Join(items, sep)).WithMarks(marks), nil
 	},
 })
 

--- a/cty/function/stdlib/string_test.go
+++ b/cty/function/stdlib/string_test.go
@@ -393,3 +393,69 @@ func TestSubstr(t *testing.T) {
 		})
 	}
 }
+
+func TestJoin(t *testing.T) {
+	tests := map[string]struct {
+		Separator cty.Value
+		Lists     []cty.Value
+		Want      cty.Value
+	}{
+		"single two-element list": {
+			cty.StringVal("-"),
+			[]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("hello"), cty.StringVal("world")}),
+			},
+			cty.StringVal("hello-world"),
+		},
+		"multiple single-element lists": {
+			cty.StringVal("-"),
+			[]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("chicken")}),
+				cty.ListVal([]cty.Value{cty.StringVal("egg")}),
+			},
+			cty.StringVal("chicken-egg"),
+		},
+		"single single-element list": {
+			cty.StringVal("-"),
+			[]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("chicken")}),
+			},
+			cty.StringVal("chicken"),
+		},
+		"blank separator": {
+			cty.StringVal(""),
+			[]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("horse"), cty.StringVal("face")}),
+			},
+			cty.StringVal("horseface"),
+		},
+		"marked list": {
+			cty.StringVal("-"),
+			[]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("hello"), cty.StringVal("world")}).Mark("sensitive"),
+			},
+			cty.StringVal("hello-world").Mark("sensitive"),
+		},
+		"marked separator": {
+			cty.StringVal("-").Mark("sensitive"),
+			[]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("hello"), cty.StringVal("world")}),
+			},
+			cty.StringVal("hello-world").Mark("sensitive"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := Join(test.Separator, test.Lists...)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}

--- a/cty/function/stdlib/string_test.go
+++ b/cty/function/stdlib/string_test.go
@@ -443,6 +443,20 @@ func TestJoin(t *testing.T) {
 			},
 			cty.StringVal("hello-world").Mark("sensitive"),
 		},
+		"list with some marked elements": {
+			cty.StringVal("-"),
+			[]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("hello").Mark("sensitive"), cty.StringVal("world")}),
+			},
+			cty.StringVal("hello-world").Mark("sensitive"),
+		},
+		"multiple marks": {
+			cty.StringVal("-").Mark("a"),
+			[]cty.Value{
+				cty.ListVal([]cty.Value{cty.StringVal("hello").Mark("b"), cty.StringVal("world").Mark("c")}),
+			},
+			cty.StringVal("hello-world").WithMarks(cty.NewValueMarks("a", "b", "c")),
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
Two commits:

- Add tests to cover some of the existing `join` function's functionality
- Add support for marked list elements as arguments to `join`

Previously the Join function would correctly handle marks on the separator or the given lists of strings, but panic if any of the lists contained strings which were marked. This commit adds support for this last case.

Calling `join(a, [b, c, d])` will return a string value marked with the union of all marks for the separator, list, and list elements.

This allows the following Terraform configuration to work:

```hcl
variable "password" {
  type      = string
  sensitive = true
  default   = "hunter2"
}

locals {
  prefixed = join("-", ["secret", var.password])
}
```