### PR TITLE
add Equal method to cty.Type

### DIFF
--- a/cty/type.go
+++ b/cty/type.go
@@ -39,6 +39,10 @@ func (t Type) Equals(other Type) bool {
 	return t.typeImpl.Equals(other)
 }
 
+func (t Type) Equal(other Type) bool {
+	return t.Equals(other)
+}
+
 // FriendlyName returns a human-friendly *English* name for the given type.
 func (t Type) FriendlyName() string {
 	return t.typeImpl.FriendlyName(friendlyTypeName)

--- a/cty/type_test.go
+++ b/cty/type_test.go
@@ -3,6 +3,8 @@ package cty
 import (
 	"fmt"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestHasDynamicTypes(t *testing.T) {
@@ -52,5 +54,19 @@ func TestHasDynamicTypes(t *testing.T) {
 				t.Errorf("Equals returned %#v; want %#v", got, test.expected)
 			}
 		})
+	}
+}
+
+func TestEqualTypes(t *testing.T) {
+	type field struct {
+		Type Type
+	}
+
+	if diff := cmp.Diff(&field{Type: String}, &field{Type: String}); diff != "" {
+		t.Fatalf("types differ: %s", diff)
+	}
+
+	if diff := cmp.Diff(&field{Type: Bool}, &field{Type: String}); diff == "" {
+		t.Fatal("expected types to differ")
 	}
 }


### PR DESCRIPTION
As demonstrated by the attached test, this method aids automatic (out-of-the-box) comparison when `cty.Type` needs to be compared for equality, such as in tests.

For context: the [`github.com/google/go-cmp`](https://github.com/google/go-cmp) library always looks for `Equal` method on any type it attempts to compare.

As part of my work on the Terraform language server I keep writing tests which need to compare schemas and these schemas often have `cty.Type` which isn't comparable, so I usually have to explicitly ignore `cty.Type`. This would make tests more accurate and also easier to write (no need for extra options).