### PR TITLE
maintain big.Float precision with multiplication and modulo

### DIFF
--- a/cty/value_ops.go
+++ b/cty/value_ops.go
@@ -596,8 +596,25 @@ func (val Value) Multiply(other Value) Value {
 		return *shortCircuit
 	}
 
-	ret := new(big.Float)
+	// find the larger precision of the arguments
+	resPrec := val.v.(*big.Float).Prec()
+	otherPrec := other.v.(*big.Float).Prec()
+	if otherPrec > resPrec {
+		resPrec = otherPrec
+	}
+
+	// make sure we have enough precision for the product
+	ret := new(big.Float).SetPrec(512)
 	ret.Mul(val.v.(*big.Float), other.v.(*big.Float))
+
+	// now reduce the precision back to the greater argument, or the minimum
+	// required by the product.
+	minPrec := ret.MinPrec()
+	if minPrec > resPrec {
+		resPrec = minPrec
+	}
+	ret.SetPrec(resPrec)
+
 	return NumberVal(ret)
 }
 

--- a/cty/value_ops.go
+++ b/cty/value_ops.go
@@ -669,11 +669,14 @@ func (val Value) Modulo(other Value) Value {
 	// FIXME: This is a bit clumsy. Should come back later and see if there's a
 	// more straightforward way to do this.
 	rat := val.Divide(other)
-	ratFloorInt := &big.Int{}
-	rat.v.(*big.Float).Int(ratFloorInt)
-	work := (&big.Float{}).SetInt(ratFloorInt)
+	ratFloorInt, _ := rat.v.(*big.Float).Int(nil)
+
+	// start with a copy of the original larger value so that we do not lose
+	// precision.
+	v := val.v.(*big.Float)
+	work := new(big.Float).Copy(v).SetInt(ratFloorInt)
 	work.Mul(other.v.(*big.Float), work)
-	work.Sub(val.v.(*big.Float), work)
+	work.Sub(v, work)
 
 	return NumberVal(work)
 }

--- a/cty/value_ops_test.go
+++ b/cty/value_ops_test.go
@@ -1953,6 +1953,11 @@ func TestValueModulo(t *testing.T) {
 			NumberIntVal(10).Mark(2),
 			Zero.WithMarks(NewValueMarks(1, 2)),
 		},
+		{
+			MustParseNumberVal("967323432120515089486873574508975134568969931547"),
+			NumberIntVal(10),
+			NumberIntVal(7),
+		},
 	}
 
 	for _, test := range tests {

--- a/cty/value_ops_test.go
+++ b/cty/value_ops_test.go
@@ -1777,6 +1777,17 @@ func TestValueMultiply(t *testing.T) {
 			Zero.Mark(2),
 			Zero.WithMarks(NewValueMarks(1, 2)),
 		},
+		{
+			MustParseNumberVal("967323432120515089486873574508975134568969931547"),
+			NumberFloatVal(12345),
+			MustParseNumberVal("11941607769527758779715454277313298036253933804947715"),
+		},
+		//
+		{
+			NumberFloatVal(22337203685475.5),
+			NumberFloatVal(22337203685475.5),
+			MustParseNumberVal("498950668486420259929661100.25"),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
There are probably other places where arbitrarily large values can
overflow the default precision creating unexpected results, but
these two points are the easiest to encounter. There is also
the issue that many functions drop down to operating on native float64
or int  internally (`floor`, `log`, `pow`, etc.). I chose to only handle
the `Multiply` and `Modulo` functions at this time, since they were
already using arbitrary precision values throughout.


- Do not lose precision in module function:

When working with big.Float values, it is imperative to ensure the
desired precision for the operations is maintained throughout. The
default precision for a Float is set initially by the max argument
precision when creating the non-zero value. If this is coming from a
Float which was set via SetInt, and that Int value was created by
SetInt64, then the precision is only 64 bits.

- Don't overflow precision in Multiply:

The product of the arguments may require more precision than either
argument. The working precision was chosen to be 512, since that is
the value used with parsing large numbers from a string.
