### PR TITLE
Type.Equals: prevent crash when comparing NilType

### DIFF
--- a/cty/type.go
+++ b/cty/type.go
@@ -36,6 +36,9 @@ func (t typeImplSigil) isTypeImpl() typeImplSigil {
 // Equals returns true if the other given Type exactly equals the receiver
 // type.
 func (t Type) Equals(other Type) bool {
+	if t == NilType || other == NilType {
+		return t == other
+	}
 	return t.typeImpl.Equals(other)
 }
 

--- a/cty/type_test.go
+++ b/cty/type_test.go
@@ -54,3 +54,10 @@ func TestHasDynamicTypes(t *testing.T) {
 		})
 	}
 }
+
+func TestNilTypeEquals(t *testing.T) {
+	var typ Type
+	if !typ.Equals(NilType) {
+		t.Fatal("expected NilTypes to equal")
+	}
+}


### PR DESCRIPTION
This is useful in combination with https://github.com/zclconf/go-cty-debug and https://github.com/google/go-cmp when comparing structs which may have `cty.Type` field which is optional, i.e. `NilType` is a valid value in that particular context.
