### PR TITLE
Add snake_case, kebab-case and camelCase functions

### DIFF
--- a/cty/function/stdlib/string.go
+++ b/cty/function/stdlib/string.go
@@ -443,6 +443,69 @@ var TrimSuffixFunc = function.New(&function.Spec{
 	},
 })
 
+var SnakeCaseFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name:             "str",
+			Type:             cty.String,
+			AllowDynamicType: true,
+		},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		in := args[0].AsString()
+		// Remove non alpha-numerics
+		out := regexp.MustCompile(`(?m)[^a-zA-Z0-9]`).ReplaceAllString(in, "_")
+		// Split on uppercase characters followed by lower case (e.g. camel case)
+		out = regexp.MustCompile(`(?m)[A-Z][a-z]`).ReplaceAllString(out, "_$0")
+		// Remove any consecutive underscores
+		out = regexp.MustCompile(`(?m)_+`).ReplaceAllString(out, "_")
+		// Remove leading/trailing underscore
+		out = regexp.MustCompile(`^_|_$`).ReplaceAllString(out, "")
+		return cty.StringVal(strings.ToLower(out)), nil
+	},
+})
+
+
+var KebabCaseFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name:             "str",
+			Type:             cty.String,
+			AllowDynamicType: true,
+		},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		in := args[0]
+		out, _ := SnakeCase(in)
+		return cty.StringVal(strings.ReplaceAll(out.AsString(), "_", "-")), nil
+	},
+})
+
+var CamelCaseFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name:             "str",
+			Type:             cty.String,
+			AllowDynamicType: true,
+		},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		in := args[0]
+		snake, _ := SnakeCase(in)
+		words := strings.ReplaceAll(snake.AsString(), "_", " ")
+		pascal := strings.ReplaceAll(strings.Title(words), " ", "")
+
+		if pascal != "" {
+			camel := string(strings.ToLower(pascal)[0]) + pascal[1:]
+			return cty.StringVal(camel), nil
+		}
+		return cty.StringVal(""), nil
+	},
+})
+
 // Upper is a Function that converts a given string to uppercase.
 func Upper(str cty.Value) (cty.Value, error) {
 	return UpperFunc.Call([]cty.Value{str})
@@ -544,4 +607,19 @@ func TrimPrefix(str, prefix cty.Value) (cty.Value, error) {
 // TrimSuffix removes the specified suffix from the end of the given string.
 func TrimSuffix(str, suffix cty.Value) (cty.Value, error) {
 	return TrimSuffixFunc.Call([]cty.Value{str, suffix})
+}
+
+// SnakeCase is a Function that converts a given string to snake_case.
+func SnakeCase(str cty.Value) (cty.Value, error) {
+	return SnakeCaseFunc.Call([]cty.Value{str})
+}
+
+// KebabCase is a Function that converts a given string to kebab-case.
+func KebabCase(str cty.Value) (cty.Value, error) {
+	return KebabCaseFunc.Call([]cty.Value{str})
+}
+
+// KebabCase is a Function that converts a given string to kebab-case.
+func CamelCase(str cty.Value) (cty.Value, error) {
+	return CamelCaseFunc.Call([]cty.Value{str})
 }

--- a/cty/function/stdlib/string_test.go
+++ b/cty/function/stdlib/string_test.go
@@ -473,3 +473,201 @@ func TestJoin(t *testing.T) {
 		})
 	}
 }
+
+func TestSnakeCase(t *testing.T) {
+	tests := []struct {
+		Input cty.Value
+		Want  cty.Value
+	}{
+		{
+			cty.StringVal("hello_world"),
+			cty.StringVal("hello_world"),
+		},
+		{
+			cty.StringVal("HelloWorld"),
+			cty.StringVal("hello_world"),
+		},
+		{
+			cty.StringVal("ABC"),
+			cty.StringVal("abc"),
+		},
+		{
+			cty.StringVal("ABCd"),
+			cty.StringVal("ab_cd"),
+		},
+		{
+			cty.StringVal("_hello_world_"),
+			cty.StringVal("hello_world"),
+		},
+		{
+			cty.StringVal("snake_case"),
+			cty.StringVal("snake_case"),
+		},
+		{
+			cty.StringVal("PascalCase"),
+			cty.StringVal("pascal_case"),
+		},
+		{
+			cty.StringVal("camelCase"),
+			cty.StringVal("camel_case"),
+		},
+		{
+			cty.StringVal("kebab-case"),
+			cty.StringVal("kebab_case"),
+		},
+		{
+			cty.StringVal(""),
+			cty.StringVal(""),
+		},
+		{
+			cty.StringVal("1"),
+			cty.StringVal("1"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Input.GoString(), func(t *testing.T) {
+			got, err := SnakeCase(test.Input)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}
+
+func TestKebabCase(t *testing.T) {
+	tests := []struct {
+		Input cty.Value
+		Want  cty.Value
+	}{
+		{
+			cty.StringVal("hello_world"),
+			cty.StringVal("hello-world"),
+		},
+		{
+			cty.StringVal("HelloWorld"),
+			cty.StringVal("hello-world"),
+		},
+		{
+			cty.StringVal("ABC"),
+			cty.StringVal("abc"),
+		},
+		{
+			cty.StringVal("ABCd"),
+			cty.StringVal("ab-cd"),
+		},
+		{
+			cty.StringVal("_hello_world_"),
+			cty.StringVal("hello-world"),
+		},
+		{
+			cty.StringVal("snake_case"),
+			cty.StringVal("snake-case"),
+		},
+		{
+			cty.StringVal("PascalCase"),
+			cty.StringVal("pascal-case"),
+		},
+		{
+			cty.StringVal("camelCase"),
+			cty.StringVal("camel-case"),
+		},
+		{
+			cty.StringVal("kebab-case"),
+			cty.StringVal("kebab-case"),
+		},
+		{
+			cty.StringVal(""),
+			cty.StringVal(""),
+		},
+		{
+			cty.StringVal("1"),
+			cty.StringVal("1"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Input.GoString(), func(t *testing.T) {
+			got, err := KebabCase(test.Input)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}
+
+func TestCamelCase(t *testing.T) {
+	tests := []struct {
+		Input cty.Value
+		Want  cty.Value
+	}{
+		{
+			cty.StringVal("hello_world"),
+			cty.StringVal("helloWorld"),
+		},
+		{
+			cty.StringVal("HelloWorld"),
+			cty.StringVal("helloWorld"),
+		},
+		{
+			cty.StringVal("ABC"),
+			cty.StringVal("abc"),
+		},
+		{
+			cty.StringVal("ABCd"),
+			cty.StringVal("abCd"),
+		},
+		{
+			cty.StringVal("_hello_world_"),
+			cty.StringVal("helloWorld"),
+		},
+		{
+			cty.StringVal("snake_case"),
+			cty.StringVal("snakeCase"),
+		},
+		{
+			cty.StringVal("PascalCase"),
+			cty.StringVal("pascalCase"),
+		},
+		{
+			cty.StringVal("camelCase"),
+			cty.StringVal("camelCase"),
+		},
+		{
+			cty.StringVal("kebab-case"),
+			cty.StringVal("kebabCase"),
+		},
+		{
+			cty.StringVal(""),
+			cty.StringVal(""),
+		},
+		{
+			cty.StringVal("1"),
+			cty.StringVal("1"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Input.GoString(), func(t *testing.T) {
+			got, err := CamelCase(test.Input)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A lot of cloud resources have names that generally follow a particular string case convention, when incorporating variables into resource names it would be useful to force it to adopt that case style. You can get some way with that in terraform by using functions like `title`, `lower`, `replace` but it would cleaner to provide those functions.

I created these functions here before I saw the comment in https://github.com/zclconf/go-cty/pull/63 - but I'm happy to port these changes into the terraform repository if that is deemed more appropriate. 