### PR TITLE
Fix CoalesceList panic when passed null arguments

### DIFF
--- a/cty/function/stdlib/collection.go
+++ b/cty/function/stdlib/collection.go
@@ -251,6 +251,10 @@ var CoalesceListFunc = function.New(&function.Spec{
 				return cty.UnknownVal(retType), nil
 			}
 
+			if arg.IsNull() {
+				continue
+			}
+
 			if arg.LengthInt() > 0 {
 				return arg, nil
 			}

--- a/cty/function/stdlib/collection_test.go
+++ b/cty/function/stdlib/collection_test.go
@@ -843,3 +843,136 @@ func TestElement(t *testing.T) {
 		})
 	}
 }
+
+func TestCoalesceList(t *testing.T) {
+	tests := map[string]struct {
+		Values []cty.Value
+		Want   cty.Value
+		Err    bool
+	}{
+		"returns first list if non-empty": {
+			[]cty.Value{
+				cty.ListVal([]cty.Value{
+					cty.StringVal("a"),
+					cty.StringVal("b"),
+				}),
+				cty.ListVal([]cty.Value{
+					cty.StringVal("c"),
+					cty.StringVal("d"),
+				}),
+			},
+			cty.ListVal([]cty.Value{
+				cty.StringVal("a"),
+				cty.StringVal("b"),
+			}),
+			false,
+		},
+		"returns second list if first is empty": {
+			[]cty.Value{
+				cty.ListValEmpty(cty.String),
+				cty.ListVal([]cty.Value{
+					cty.StringVal("c"),
+					cty.StringVal("d"),
+				}),
+			},
+			cty.ListVal([]cty.Value{
+				cty.StringVal("c"),
+				cty.StringVal("d"),
+			}),
+			false,
+		},
+		"return type is dynamic, not unified": {
+			[]cty.Value{
+				cty.ListValEmpty(cty.String),
+				cty.ListVal([]cty.Value{
+					cty.NumberIntVal(3),
+					cty.NumberIntVal(4),
+				}),
+			},
+			cty.ListVal([]cty.Value{
+				cty.NumberIntVal(3),
+				cty.NumberIntVal(4),
+			}),
+			false,
+		},
+		"works with tuples": {
+			[]cty.Value{
+				cty.EmptyTupleVal,
+				cty.TupleVal([]cty.Value{
+					cty.StringVal("c"),
+					cty.StringVal("d"),
+				}),
+			},
+			cty.TupleVal([]cty.Value{
+				cty.StringVal("c"),
+				cty.StringVal("d"),
+			}),
+			false,
+		},
+		"unknown arguments": {
+			[]cty.Value{
+				cty.UnknownVal(cty.List(cty.String)),
+				cty.ListVal([]cty.Value{
+					cty.StringVal("c"),
+					cty.StringVal("d"),
+				}),
+			},
+			cty.DynamicVal,
+			false,
+		},
+		"null arguments": {
+			[]cty.Value{
+				cty.NullVal(cty.List(cty.String)),
+				cty.ListVal([]cty.Value{
+					cty.StringVal("c"),
+					cty.StringVal("d"),
+				}),
+			},
+			cty.ListVal([]cty.Value{
+				cty.StringVal("c"),
+				cty.StringVal("d"),
+			}),
+			false,
+		},
+		"all null arguments": {
+			[]cty.Value{
+				cty.NullVal(cty.List(cty.String)),
+				cty.NullVal(cty.List(cty.String)),
+			},
+			cty.NilVal,
+			true,
+		},
+		"invalid arguments": {
+			[]cty.Value{
+				cty.MapVal(map[string]cty.Value{"a": cty.True}),
+				cty.ObjectVal(map[string]cty.Value{"b": cty.False}),
+			},
+			cty.NilVal,
+			true,
+		},
+		"no arguments": {
+			[]cty.Value{},
+			cty.NilVal,
+			true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := CoalesceList(test.Values...)
+
+			if test.Err {
+				if err == nil {
+					t.Fatal("succeeded; want error")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `coalescelist` function was moved here from hashicorp/terraform in #37. While [the Terraform function documentation doesn't specify whether or not `null` arguments are permitted](https://www.terraform.io/docs/configuration/functions/coalescelist.html), the implementation does allow them: https://github.com/zclconf/go-cty/blob/4a538861ac5cc80538f5aac666ba6f2b85d0af10/cty/function/stdlib/collection.go#L205-L213

However as reported in https://github.com/hashicorp/terraform/issues/26988, passing a `null` argument causes a panic. This commit fixes the crash and adds test coverage for the function.