### PR TITLE
functions/stdlib/merge: return an empty object when all inputs are null

### DIFF
--- a/cty/function/stdlib/collection.go
+++ b/cty/function/stdlib/collection.go
@@ -758,16 +758,10 @@ var MergeFunc = function.New(&function.Spec{
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
 		outputMap := make(map[string]cty.Value)
 
-		// if all inputs are null, return a null value rather than an object
-		// with null attributes
-		allNull := true
 		for _, arg := range args {
 			if arg.IsNull() {
 				continue
-			} else {
-				allNull = false
 			}
-
 			for it := arg.ElementIterator(); it.Next(); {
 				k, v := it.Element()
 				outputMap[k.AsString()] = v
@@ -775,8 +769,6 @@ var MergeFunc = function.New(&function.Spec{
 		}
 
 		switch {
-		case allNull:
-			return cty.NullVal(retType), nil
 		case retType.IsMapType():
 			if len(outputMap) == 0 {
 				return cty.MapValEmpty(retType.ElementType()), nil

--- a/cty/function/stdlib/collection_test.go
+++ b/cty/function/stdlib/collection_test.go
@@ -301,6 +301,13 @@ func TestMerge(t *testing.T) {
 			cty.EmptyObjectVal,
 			false,
 		},
+		{ // single null input
+			[]cty.Value{
+				cty.MapValEmpty(cty.String),
+			},
+			cty.EmptyObjectVal,
+			false,
+		},
 		{ // handle null object
 			[]cty.Value{
 				cty.MapVal(map[string]cty.Value{

--- a/cty/function/stdlib/collection_test.go
+++ b/cty/function/stdlib/collection_test.go
@@ -291,14 +291,14 @@ func TestMerge(t *testing.T) {
 			}),
 			false,
 		},
-		{ // handle null map
+		{ // all inputs are null
 			[]cty.Value{
 				cty.NullVal(cty.Map(cty.String)),
 				cty.NullVal(cty.Object(map[string]cty.Type{
 					"a": cty.List(cty.String),
 				})),
 			},
-			cty.NullVal(cty.EmptyObject),
+			cty.EmptyObjectVal,
 			false,
 		},
 		{ // handle null object


### PR DESCRIPTION
It seems intuitive for merge() to return an empty object when the inputs
are null (or omitted entirely) - returning an error would likely break
many terraform configurations, and returning an empty object rather than
null seems more consistent with the documented behavior (though it is
not explicit!).

I dug through the commit history and compared terraform's documentation,
post pre- and post-hcl2, and did not find any clues as to why it was
returning null rather than an empty object. I feel like this is an
acceptable breaking change, but am certainly open to other opinions.