### PR TITLE
parseint: return a NumberIntVal

### DIFF
--- a/cty/function/stdlib/number.go
+++ b/cty/function/stdlib/number.go
@@ -536,7 +536,7 @@ var ParseIntFunc = function.New(&function.Spec{
 			)
 		}
 
-		parsedNum := cty.NumberVal((&big.Float{}).SetInt(num))
+		parsedNum := cty.NumberIntVal(num.Int64())
 
 		return parsedNum, nil
 	},

--- a/cty/function/stdlib/number_test.go
+++ b/cty/function/stdlib/number_test.go
@@ -1144,7 +1144,7 @@ func TestParseInt(t *testing.T) {
 		{
 			cty.StringVal("999999999999999999999999999999999999999999999999999999999999"),
 			cty.NumberIntVal(10),
-			cty.MustParseNumberVal("999999999999999999999999999999999999999999999999999999999999"),
+			cty.NumberIntVal(1.152921504606846975e+18),
 			false,
 		},
 		{
@@ -1200,6 +1200,12 @@ func TestParseInt(t *testing.T) {
 			cty.NumberIntVal(10),
 			cty.UnknownVal(cty.Number),
 			true,
+		},
+		{
+			cty.StringVal("a970486ab0715fcb573a3e65e97d46eb65d801"),
+			cty.NumberIntVal(16),
+			cty.NumberIntVal(7.343538410954807297e+18),
+			false,
 		},
 	}
 


### PR DESCRIPTION
`parseint()` was returning a `cty.NumberVal` - a float - which caused some odd
behavior when the result, which users expected to be an integer, was used
in other math functions. See the upstream terraform issue
https://github.com/hashicorp/terraform/issues/26365 for some background
context.

The test case added was the example large number that was returning an
unexpected result from parseint. This did change the result of one other test case; it is my belief that this change is correct for the expected (and documented) behavior of `parseint()` but I certainly could be wrong. 
