### PR TITLE
cty: Allow list of vals with partly-dynamic types

### DIFF
--- a/cty/value_init_test.go
+++ b/cty/value_init_test.go
@@ -116,3 +116,92 @@ func TestSetVal_nestedStructures(t *testing.T) {
 		})
 	}
 }
+
+func TestListVal(t *testing.T) {
+	testCases := []struct {
+		Name  string
+		Elems []Value
+	}{
+		{
+			"integers",
+			[]Value{
+				NumberIntVal(5),
+				NumberIntVal(10),
+			},
+		},
+		{
+			"strings",
+			[]Value{
+				StringVal("boop"),
+				StringVal("beep"),
+			},
+		},
+		{
+			"all dynamic values",
+			[]Value{
+				DynamicVal,
+				DynamicVal,
+				DynamicVal,
+			},
+		},
+		{
+			"some dynamic values",
+			[]Value{
+				DynamicVal,
+				NumberIntVal(5),
+				DynamicVal,
+				NumberIntVal(10),
+				DynamicVal,
+			},
+		},
+		{
+			"nested dynamic values",
+			[]Value{
+				ObjectVal(map[string]Value{
+					"foo": NumberIntVal(5),
+					"bar": StringVal("beep"),
+				}),
+				ObjectVal(map[string]Value{
+					"foo": NumberIntVal(5),
+					"bar": DynamicVal,
+				}),
+			},
+		},
+		{
+			"nested dynamic values, dynamic first",
+			[]Value{
+				ObjectVal(map[string]Value{
+					"foo": NumberIntVal(5),
+					"bar": StringVal("beep"),
+				}),
+				ObjectVal(map[string]Value{
+					"foo": NumberIntVal(5),
+					"bar": DynamicVal,
+				}),
+			},
+		},
+		{
+			// This test case documents that this call does not panic, but will
+			// result in an invalid list. We may want to change this behaviour
+			// later.
+			"incompatible but dynamic object types",
+			[]Value{
+				ObjectVal(map[string]Value{
+					"foo": NumberIntVal(5),
+					"bar": StringVal("beep"),
+					"baz": DynamicVal,
+				}),
+				ObjectVal(map[string]Value{
+					"foo": NumberIntVal(5),
+					"bar": DynamicVal,
+				}),
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
+			ListVal(tc.Elems)
+		})
+	}
+}


### PR DESCRIPTION
The ListVal constructor function previously required that all elements had exactly the same type. In some cases involving partly-dynamic element types, this was overly strict. This commit relaxes the constraints which caused these cases to panic.

If we attempted to create a list of objects, some of which contained dynamic pseudo-type fields, the constructor would panic. For example, consider this (HCL) example:

```hcl
list = [
  {
    ids = ["1", "2"],
  },
  {
    ids = [for obj in some_dynamic_list: obj.id],
  },
]
```

This panic happened because the two element types were different: namely, `Object({ ids: string })` and `Object({ ids: dynamic })`. However, these types are unifiable, and the convert package calls `ListVal` after verifying this.

Instead of strictly comparing all element types, we now only panic if the list contains two or more elements with fully concrete types which are inequal. Element types which are dynamic or partly dynamic are permitted.

Downstream issue, verified fixed with this change: https://github.com/hashicorp/terraform/issues/27275

---

I'm not sure this is the right approach to solving this problem. It feels inelegant, but I can't think of a better solution. If we do want to change this behaviour, the change should probably also be applied to `MapVal` and `SetVal`, which follow a similar pattern for checking dynamic element types.