### PR TITLE
Fix Object GoString()

### DIFF
--- a/cty/object_type.go
+++ b/cty/object_type.go
@@ -112,7 +112,7 @@ func (t typeObject) GoString() string {
 		return "cty.EmptyObject"
 	}
 	if len(t.AttrOptional) > 0 {
-		opt := make([]string, len(t.AttrOptional))
+		var opt []string
 		for k := range t.AttrOptional {
 			opt = append(opt, k)
 		}

--- a/cty/type_test.go
+++ b/cty/type_test.go
@@ -61,3 +61,91 @@ func TestNilTypeEquals(t *testing.T) {
 		t.Fatal("expected NilTypes to equal")
 	}
 }
+
+func TestTypeGoString(t *testing.T) {
+	tests := []struct {
+		Type Type
+		Want string
+	}{
+		{
+			DynamicPseudoType,
+			`cty.DynamicPseudoType`,
+		},
+		{
+			String,
+			`cty.String`,
+		},
+		{
+			Tuple([]Type{String, Bool}),
+			`cty.Tuple([]cty.Type{cty.String, cty.Bool})`,
+		},
+
+		{
+			Number,
+			`cty.Number`,
+		},
+		{
+			Bool,
+			`cty.Bool`,
+		},
+		{
+			List(String),
+			`cty.List(cty.String)`,
+		},
+		{
+			List(List(String)),
+			`cty.List(cty.List(cty.String))`,
+		},
+		{
+			List(Bool),
+			`cty.List(cty.Bool)`,
+		},
+		{
+			Set(String),
+			`cty.Set(cty.String)`,
+		},
+		{
+			Set(Map(String)),
+			`cty.Set(cty.Map(cty.String))`,
+		},
+		{
+			Set(Bool),
+			`cty.Set(cty.Bool)`,
+		},
+		{
+			Tuple([]Type{Bool}),
+			`cty.Tuple([]cty.Type{cty.Bool})`,
+		},
+
+		{
+			Map(String),
+			`cty.Map(cty.String)`,
+		},
+		{
+			Map(Set(String)),
+			`cty.Map(cty.Set(cty.String))`,
+		},
+		{
+			Map(Bool),
+			`cty.Map(cty.Bool)`,
+		},
+		{
+			Object(map[string]Type{"foo": Bool}),
+			`cty.Object(map[string]cty.Type{"foo":cty.Bool})`,
+		},
+		{
+			ObjectWithOptionalAttrs(map[string]Type{"foo": Bool, "bar": String}, []string{"bar"}),
+			`cty.ObjectWithOptionalAttrs(map[string]cty.Type{"bar":cty.String, "foo":cty.Bool}, []string{"bar"})`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Type.GoString(), func(t *testing.T) {
+			got := test.Type.GoString()
+			want := test.Want
+			if got != want {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The returned `GoString()` for a `cty.ObjectWithOptionalAttrs` was a bit off;
the returned slice of optional attributes was twice as long as it needed
to be due to a mismatch where the slice was created with make, but then
appended to (as opposed to indexed into).

I didn't see test coverage for `Type` `GoString()`, so I copied the test cases from Value's `GoString()` (fewer test cases, since I didn't need to differentiate between null and empty values). Here's the related test before the fix:


```--- FAIL: TestTypeGoString (0.00s)
    --- FAIL: TestTypeGoString/cty.ObjectWithOptionalAttrs(map[string]cty.Type{"bar":cty.String,_"foo":cty.Bool},_[]string{"",_"bar"}) (0.00s)
        type_test.go:147: wrong result
            got:  cty.ObjectWithOptionalAttrs(map[string]cty.Type{"bar":cty.String, "foo":cty.Bool}, []string{"", "bar"})
            want: cty.ObjectWithOptionalAttrs(map[string]cty.Type{"bar":cty.String, "foo":cty.Bool}, []string{"bar"})
```

