### PR TITLE
Optional attributes fixes

### DIFF
--- a/cty/convert/conversion.go
+++ b/cty/convert/conversion.go
@@ -40,6 +40,16 @@ func getConversion(in cty.Type, out cty.Type, unsafe bool) conversion {
 			// We'll pass through nulls, albeit type converted, and let
 			// the caller deal with whatever handling they want to do in
 			// case null values are considered valid in some applications.
+
+			// Avoid constructing values with types which include optional
+			// attributes. Non-null object values will be passed to a
+			// conversion function which drops the optional attributes from the
+			// type. Null pass through values must do the same to ensure that
+			// homogeneous collections have a single element type.
+			if out.IsObjectType() && len(out.OptionalAttributes()) > 0 {
+				out = cty.Object(out.AttributeTypes())
+			}
+
 			return cty.NullVal(out), nil
 		}
 

--- a/cty/convert/conversion.go
+++ b/cty/convert/conversion.go
@@ -33,24 +33,25 @@ func getConversion(in cty.Type, out cty.Type, unsafe bool) conversion {
 			// Conversion to DynamicPseudoType always just passes through verbatim.
 			return in, nil
 		}
-		if !in.IsKnown() {
-			return cty.UnknownVal(out), nil
-		}
-		if in.IsNull() {
-			// We'll pass through nulls, albeit type converted, and let
-			// the caller deal with whatever handling they want to do in
-			// case null values are considered valid in some applications.
+		if isKnown, isNull := in.IsKnown(), in.IsNull(); !isKnown || isNull {
+			// Avoid constructing unknown or null values with types which
+			// include optional attributes. Known or non-null object values
+			// will be passed to a conversion function which drops the optional
+			// attributes from the type. Unknown and null pass through values
+			// must do the same to ensure that homogeneous collections have a
+			// single element type.
+			out = out.WithoutOptionalAttributesDeep()
 
-			// Avoid constructing values with types which include optional
-			// attributes. Non-null object values will be passed to a
-			// conversion function which drops the optional attributes from the
-			// type. Null pass through values must do the same to ensure that
-			// homogeneous collections have a single element type.
-			if out.IsObjectType() && len(out.OptionalAttributes()) > 0 {
-				out = cty.Object(out.AttributeTypes())
+			if !isKnown {
+				return cty.UnknownVal(out), nil
 			}
 
-			return cty.NullVal(out), nil
+			if isNull {
+				// We'll pass through nulls, albeit type converted, and let
+				// the caller deal with whatever handling they want to do in
+				// case null values are considered valid in some applications.
+				return cty.NullVal(out), nil
+			}
 		}
 
 		return conv(in, path)

--- a/cty/convert/public_test.go
+++ b/cty/convert/public_test.go
@@ -576,6 +576,45 @@ func TestConvert(t *testing.T) {
 			WantError: true, // Attribute "bar" is required
 		},
 		{
+			Value: cty.NullVal(cty.DynamicPseudoType),
+			Type: cty.ObjectWithOptionalAttrs(
+				map[string]cty.Type{
+					"foo": cty.String,
+					"bar": cty.String,
+				},
+				[]string{"foo"},
+			),
+			Want: cty.NullVal(cty.Object(map[string]cty.Type{
+				"foo": cty.String,
+				"bar": cty.String,
+			})),
+		},
+		{
+			Value: cty.ListVal([]cty.Value{
+				cty.NullVal(cty.DynamicPseudoType),
+				cty.ObjectVal(map[string]cty.Value{
+					"bar": cty.StringVal("bar value"),
+				}),
+			}),
+			Type: cty.List(cty.ObjectWithOptionalAttrs(
+				map[string]cty.Type{
+					"foo": cty.String,
+					"bar": cty.String,
+				},
+				[]string{"foo"},
+			)),
+			Want: cty.ListVal([]cty.Value{
+				cty.NullVal(cty.Object(map[string]cty.Type{
+					"foo": cty.String,
+					"bar": cty.String,
+				})),
+				cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.NullVal(cty.String),
+					"bar": cty.StringVal("bar value"),
+				}),
+			}),
+		},
+		{
 			Value: cty.ObjectVal(map[string]cty.Value{
 				"foo": cty.True,
 			}),

--- a/cty/convert/public_test.go
+++ b/cty/convert/public_test.go
@@ -832,6 +832,47 @@ func TestConvert(t *testing.T) {
 				}),
 			}),
 		},
+		// When converting null values into nested types which include objects
+		// with optional attributes, we expect the resulting value to be of a
+		// recursively concretized type.
+		{
+			Value: cty.NullVal(cty.DynamicPseudoType),
+			Type: cty.Object(
+				map[string]cty.Type{
+					"foo": cty.ObjectWithOptionalAttrs(
+						map[string]cty.Type{
+							"bar": cty.String,
+						},
+						[]string{"bar"},
+					),
+				},
+			),
+			Want: cty.NullVal(cty.Object(map[string]cty.Type{
+				"foo": cty.Object(map[string]cty.Type{
+					"bar": cty.String,
+				}),
+			})),
+		},
+		// The same nested optional attributes flattening should happen for
+		// unknown values, too.
+		{
+			Value: cty.UnknownVal(cty.DynamicPseudoType),
+			Type: cty.Object(
+				map[string]cty.Type{
+					"foo": cty.ObjectWithOptionalAttrs(
+						map[string]cty.Type{
+							"bar": cty.String,
+						},
+						[]string{"bar"},
+					),
+				},
+			),
+			Want: cty.UnknownVal(cty.Object(map[string]cty.Type{
+				"foo": cty.Object(map[string]cty.Type{
+					"bar": cty.String,
+				}),
+			})),
+		},
 		// https://github.com/hashicorp/terraform/issues/21588:
 		{
 			Value: cty.TupleVal([]cty.Value{

--- a/cty/convert/public_test.go
+++ b/cty/convert/public_test.go
@@ -787,6 +787,51 @@ func TestConvert(t *testing.T) {
 				"b": cty.MapValEmpty(cty.String),
 			}),
 		},
+		// reduction of https://github.com/hashicorp/terraform/issues/27269
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"a": cty.NullVal(cty.DynamicPseudoType),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"b": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"c": cty.StringVal("d"),
+							}),
+						}),
+					}),
+				}),
+			}),
+			Type: cty.List(cty.Object(map[string]cty.Type{
+				"a": cty.Object(map[string]cty.Type{
+					"b": cty.List(cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+						"c": cty.String,
+						"d": cty.String,
+					}, []string{"d"})),
+				}),
+			})),
+			Want: cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"a": cty.NullVal(cty.Object(map[string]cty.Type{
+						"b": cty.List(cty.Object(map[string]cty.Type{
+							"c": cty.String,
+							"d": cty.String,
+						})),
+					})),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"b": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"c": cty.StringVal("d"),
+								"d": cty.NullVal(cty.String),
+							}),
+						}),
+					}),
+				}),
+			}),
+		},
 		// https://github.com/hashicorp/terraform/issues/21588:
 		{
 			Value: cty.TupleVal([]cty.Value{

--- a/cty/type.go
+++ b/cty/type.go
@@ -115,6 +115,44 @@ func (t Type) HasDynamicTypes() bool {
 	}
 }
 
+// WithoutOptionalAttributesDeep returns a type equivalent to the receiver but
+// with any objects with optional attributes converted into fully concrete
+// object types. This operation is applied recursively.
+func (t Type) WithoutOptionalAttributesDeep() Type {
+	switch {
+	case t == DynamicPseudoType, t.IsPrimitiveType(), t.IsCapsuleType():
+		return t
+	case t.IsMapType():
+		return Map(t.ElementType().WithoutOptionalAttributesDeep())
+	case t.IsListType():
+		return List(t.ElementType().WithoutOptionalAttributesDeep())
+	case t.IsSetType():
+		return Set(t.ElementType().WithoutOptionalAttributesDeep())
+	case t.IsTupleType():
+		originalElemTypes := t.TupleElementTypes()
+		elemTypes := make([]Type, len(originalElemTypes))
+		for i, et := range originalElemTypes {
+			elemTypes[i] = et.WithoutOptionalAttributesDeep()
+		}
+		return Tuple(elemTypes)
+	case t.IsObjectType():
+		originalAttrTypes := t.AttributeTypes()
+		attrTypes := make(map[string]Type, len(originalAttrTypes))
+		for k, t := range originalAttrTypes {
+			attrTypes[k] = t.WithoutOptionalAttributesDeep()
+		}
+
+		// This is the subtle line which does all the work of this function: by
+		// constructing a new Object type with these attribute types, we drop
+		// the list of optional attributes (if present). This results in a
+		// concrete Object type which requires all of the original attributes.
+		return Object(attrTypes)
+	default:
+		// Should never happen, since above should be exhaustive
+		panic("WithoutOptionalAttributesDeep does not support the given type")
+	}
+}
+
 type friendlyTypeNameMode rune
 
 const (

--- a/cty/type_test.go
+++ b/cty/type_test.go
@@ -55,6 +55,105 @@ func TestHasDynamicTypes(t *testing.T) {
 	}
 }
 
+func TestWithoutOptionalAttributesDeep(t *testing.T) {
+	tests := []struct {
+		ty       Type
+		expected Type
+	}{
+		{
+			DynamicPseudoType,
+			DynamicPseudoType,
+		},
+		{
+			List(DynamicPseudoType),
+			List(DynamicPseudoType),
+		},
+		{
+			Tuple([]Type{String, DynamicPseudoType}),
+			Tuple([]Type{String, DynamicPseudoType}),
+		},
+		{
+			Object(map[string]Type{
+				"a":       String,
+				"unknown": DynamicPseudoType,
+			}),
+			Object(map[string]Type{
+				"a":       String,
+				"unknown": DynamicPseudoType,
+			}),
+		},
+		{
+			ObjectWithOptionalAttrs(map[string]Type{
+				"a":       String,
+				"unknown": DynamicPseudoType,
+			}, []string{"a"}),
+			Object(map[string]Type{
+				"a":       String,
+				"unknown": DynamicPseudoType,
+			}),
+		},
+		{
+			Map(ObjectWithOptionalAttrs(map[string]Type{
+				"a":       String,
+				"unknown": DynamicPseudoType,
+			}, []string{"a"})),
+			Map(Object(map[string]Type{
+				"a":       String,
+				"unknown": DynamicPseudoType,
+			})),
+		},
+		{
+			Set(ObjectWithOptionalAttrs(map[string]Type{
+				"a":       String,
+				"unknown": DynamicPseudoType,
+			}, []string{"a"})),
+			Set(Object(map[string]Type{
+				"a":       String,
+				"unknown": DynamicPseudoType,
+			})),
+		},
+		{
+			List(ObjectWithOptionalAttrs(map[string]Type{
+				"a":       String,
+				"unknown": DynamicPseudoType,
+			}, []string{"a"})),
+			List(Object(map[string]Type{
+				"a":       String,
+				"unknown": DynamicPseudoType,
+			})),
+		},
+		{
+			Tuple([]Type{
+				ObjectWithOptionalAttrs(map[string]Type{
+					"a":       String,
+					"unknown": DynamicPseudoType,
+				}, []string{"a"}),
+				ObjectWithOptionalAttrs(map[string]Type{
+					"b": Number,
+				}, []string{"b"}),
+			}),
+			Tuple([]Type{
+				Object(map[string]Type{
+					"a":       String,
+					"unknown": DynamicPseudoType,
+				}),
+				Object(map[string]Type{
+					"b": Number,
+				}),
+			}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%#v.HasDynamicTypes()", test.ty), func(t *testing.T) {
+			got := test.ty.WithoutOptionalAttributesDeep()
+			if !test.expected.Equals(got) {
+				t.Errorf("Equals returned %#v; want %#v", got, test.expected)
+			}
+		})
+	}
+}
+
 func TestNilTypeEquals(t *testing.T) {
 	var typ Type
 	if !typ.Equals(NilType) {


### PR DESCRIPTION
Two commits addressing issues related to objects with optional attributes. These commits address these downstream bugs in Terraform:

- https://github.com/hashicorp/terraform/issues/27269
- https://github.com/hashicorp/terraform/issues/27295

## Fix for null objects with optional attrs

Conversions targeting types which are or include objects with optional attributes always simplify those types, removing the optional attributes from the type, and inserting null values for any that are missing.  Objects with optional attributes are not intended to be used to instantiate values.

One accidental exception to this was the null value of dynamic type.  These values are passed through by the getConversion wrapper, assigning the desired type. This conflicts with the type simplification rules for non-null values, and can result in a panic when a collection type contains null values.

This commit fixes this at the wrapper level by performing the same type simplification when converting null into an object type.

## Fix unification of collection values

To correctly unify deep nested types, we need to unify all collection types (maps, lists, sets), not just maps. This ensures that all cousin types are unified correctly.

This problem was first addressed for maps in #47 a year ago, but we didn't realize at the time that the same bug could manifest in other collection types.
