### PR TITLE
convert: unify tuples as lists and objects as maps when possible

### DIFF
--- a/cty/convert/unify.go
+++ b/cty/convert/unify.go
@@ -219,9 +219,9 @@ func unifyObjectsAsMaps(types []cty.Type, unsafe bool) (cty.Type, []Conversion) 
 		return cty.NilType, nil
 	}
 
-	// we have a good conversion, wrap the nested tuple conversions.
-	// We know the tuple conversion is not nil, because we went from tuple to
-	// list
+	// we have a good conversion, so wrap the nested object conversions.
+	// We know the object conversion is not nil, because we went from object to
+	// map.
 	for i, idx := range objIdxs {
 		mapConv := convs[idx]
 		objConv := objConvs[i]

--- a/cty/convert/unify_test.go
+++ b/cty/convert/unify_test.go
@@ -285,6 +285,179 @@ func TestUnify(t *testing.T) {
 			[]bool{true, true},
 		},
 		{
+			// Objects and maps should unify along with the surrounding lists
+			// and tuples.
+			[]cty.Type{
+				cty.List(cty.Object(map[string]cty.Type{
+					"a": cty.Object(map[string]cty.Type{
+						"a": cty.String,
+					}),
+					"b": cty.Object(map[string]cty.Type{
+						"a": cty.String,
+						"b": cty.String,
+					}),
+				})),
+				cty.List(cty.Map(
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+						"b": cty.String,
+					}),
+				)),
+			},
+			cty.List(cty.Map(cty.Map(cty.String))),
+			[]bool{true, true},
+		},
+		{
+			// objects can unify as maps within objects
+			[]cty.Type{
+				cty.Object(map[string]cty.Type{
+					"a": cty.Object(map[string]cty.Type{
+						"a": cty.String,
+					}),
+				}),
+				cty.Object(map[string]cty.Type{
+					"a": cty.Object(map[string]cty.Type{
+						"a": cty.String,
+						"b": cty.String,
+					}),
+				}),
+			},
+			cty.Object(map[string]cty.Type{
+				"a": cty.Map(cty.String),
+			}),
+			[]bool{true, true},
+		},
+		{
+			// nested objects can unify as maps
+			[]cty.Type{
+				cty.Object(map[string]cty.Type{
+					"a": cty.Object(map[string]cty.Type{
+						"a": cty.String,
+					}),
+					"b": cty.Object(map[string]cty.Type{
+						"a": cty.String,
+						"b": cty.String,
+					}),
+				}),
+				cty.Map(
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+						"b": cty.String,
+					}),
+				),
+			},
+			cty.Map(cty.Map(cty.String)),
+			[]bool{true, true},
+		},
+		{
+			// nested tuples and lists can unify along with the surrounding
+			// objects and maps
+			[]cty.Type{
+				cty.Object(map[string]cty.Type{
+					"a": cty.Object(map[string]cty.Type{
+						"a": cty.List(cty.String),
+					}),
+					"b": cty.Object(map[string]cty.Type{
+						"a": cty.Tuple([]cty.Type{
+							cty.String,
+						}),
+						"b": cty.List(cty.String),
+					}),
+				}),
+				cty.Map(
+					cty.Object(map[string]cty.Type{
+						"a": cty.List(cty.String),
+						"b": cty.List(cty.String),
+					}),
+				),
+			},
+			cty.Map(cty.Map(cty.List(cty.String))),
+			[]bool{true, true},
+		},
+		{
+			// objects can unify as maps containing objects when all attributes
+			// match
+			[]cty.Type{
+				cty.Object(map[string]cty.Type{
+					"a": cty.Object(map[string]cty.Type{
+						"a": cty.String,
+					}),
+					"b": cty.Object(map[string]cty.Type{
+						"a": cty.String,
+					}),
+				}),
+				cty.Map(
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+					}),
+				),
+			},
+			cty.Map(
+				cty.Object(map[string]cty.Type{
+					"a": cty.String,
+				}),
+			),
+			[]bool{true, false},
+		},
+		{
+			// objects can unify as maps with dynamic types
+			[]cty.Type{
+				cty.Object(map[string]cty.Type{
+					"a": cty.Object(map[string]cty.Type{
+						"a": cty.String,
+					}),
+					"b": cty.Object(map[string]cty.Type{
+						"a": cty.String,
+					}),
+				}),
+				cty.Map(cty.DynamicPseudoType),
+				cty.Map(
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+					}),
+				),
+			},
+			cty.Map(cty.DynamicPseudoType),
+			[]bool{true, false, true},
+		},
+		{
+			// deeply nested objects and maps can unify
+			[]cty.Type{
+				cty.Object(map[string]cty.Type{
+					"a": cty.Object(map[string]cty.Type{
+						"a": cty.Object(map[string]cty.Type{
+							"a": cty.String,
+						}),
+					}),
+					"b": cty.Object(map[string]cty.Type{
+						"c": cty.Object(map[string]cty.Type{
+							"d": cty.String,
+						}),
+					}),
+				}),
+				cty.Map(cty.Map(cty.Map(cty.String))),
+			},
+			cty.Map(cty.Map(cty.Map(cty.String))),
+			[]bool{true, false},
+		},
+		{
+			// deeply nested objects with maps can unify as maps
+			[]cty.Type{
+				cty.Map(cty.Map(cty.Map(cty.String))),
+				cty.Object(map[string]cty.Type{
+					"a": cty.Object(map[string]cty.Type{
+						"a": cty.Object(map[string]cty.Type{
+							"a": cty.String,
+						}),
+						"b": cty.Map(cty.String),
+					}),
+					"b": cty.Map(cty.Map(cty.String)),
+				}),
+			},
+			cty.Map(cty.Map(cty.Map(cty.String))),
+			[]bool{false, true},
+		},
+		{
 			[]cty.Type{
 				cty.DynamicPseudoType,
 				cty.Tuple([]cty.Type{cty.Number}),

--- a/cty/convert/unify_test.go
+++ b/cty/convert/unify_test.go
@@ -143,6 +143,148 @@ func TestUnify(t *testing.T) {
 			nil,
 		},
 		{
+			// objects can unify as map(string) within the tuples
+			[]cty.Type{
+				cty.Tuple([]cty.Type{
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+					}),
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+					}),
+				}),
+				cty.Tuple([]cty.Type{
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+						"b": cty.String,
+					}),
+				}),
+			},
+			cty.List(cty.Map(cty.String)),
+			[]bool{true, true},
+		},
+		{
+			// unifies to the same result as above, since the only difference
+			// is the addition of a list
+			[]cty.Type{
+				cty.List(cty.Object(map[string]cty.Type{
+					"a": cty.String,
+				})),
+				cty.Tuple([]cty.Type{
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+						"b": cty.String,
+					}),
+				}),
+				cty.Tuple([]cty.Type{
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+						"b": cty.String,
+					}),
+					cty.Object(map[string]cty.Type{
+						"c": cty.String,
+						"d": cty.String,
+					}),
+				}),
+			},
+			cty.List(cty.Map(cty.String)),
+			[]bool{true, true, true},
+		},
+		{
+			// Ensure the map does not change the unification process
+			[]cty.Type{
+				cty.List(cty.Object(map[string]cty.Type{
+					"a": cty.String,
+				})),
+				cty.List(cty.Map(cty.String)),
+				cty.Tuple([]cty.Type{
+					cty.Map(cty.String),
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+						"b": cty.String,
+					}),
+				}),
+			},
+			cty.List(cty.Map(cty.String)),
+			[]bool{true, false, true},
+		},
+		{
+			// different tuple lengths unify as a list, and the objects can
+			// unify as maps
+			[]cty.Type{
+				cty.Tuple([]cty.Type{
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+						"b": cty.Number,
+					}),
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+						"b": cty.Number,
+					}),
+				}),
+				cty.Tuple([]cty.Type{
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+					}),
+				}),
+			},
+			cty.List(cty.Map(cty.String)),
+			[]bool{true, true},
+		},
+		{
+			// the equivalent tuple lengths still unify as a tuple, though the
+			// objects are unified as a map
+			[]cty.Type{
+				cty.Tuple([]cty.Type{
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+						"b": cty.Number,
+					}),
+				}),
+				cty.Tuple([]cty.Type{
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+					}),
+				}),
+			},
+			cty.Tuple([]cty.Type{cty.Map(cty.String)}),
+			[]bool{true, true},
+		},
+		{
+			// This should unify to like the tuple above
+			[]cty.Type{
+				cty.List(
+					cty.Object(map[string]cty.Type{
+						"a": cty.Number,
+						"b": cty.String,
+					}),
+				),
+				cty.Tuple([]cty.Type{
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+					}),
+				}),
+			},
+			cty.List(cty.Map(cty.String)),
+			[]bool{true, true},
+		},
+		{
+			// This should also unify like the previous 2 examples
+			[]cty.Type{
+				cty.List(
+					cty.Object(map[string]cty.Type{
+						"a": cty.Number,
+						"b": cty.String,
+					}),
+				),
+				cty.List(cty.Object(map[string]cty.Type{
+					"a": cty.String,
+				})),
+			},
+			cty.List(cty.Map(cty.String)),
+			[]bool{true, true},
+		},
+		{
 			[]cty.Type{
 				cty.DynamicPseudoType,
 				cty.Tuple([]cty.Type{cty.Number}),


### PR DESCRIPTION
Tuple and list unification is a common case due to the fact that list data is often in tuple form, either because of configuration language constructs or functions that must deal with possibly heterogeneous collections. In the current code, we would immediately fall back to type conversion, which has different semantics from type unification. The problem is most obvious when the tuples contains objects (which are often maps is disguise for the same reason that lists and tuples are interchanged), and the objects go through type conversion rather than type unification, where unsafe conversion can yield objects with only the intersection of attributes rather than a unified map.

Instead of falling back to direct conversion when there are only tuples and lists involved, we stay in the unification codepath and first unify the tuples as lists. That unification can correctly handle the objects contained within the tuples, then the unification of the resulting lists follows. 