### PR TITLE
cty: add CanListFunc, CanSetFunc, CanMapFunc

### DIFF
--- a/cty/convert/conversion_collection.go
+++ b/cty/convert/conversion_collection.go
@@ -1,6 +1,8 @@
 package convert
 
 import (
+	"fmt"
+
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -51,6 +53,10 @@ func conversionCollectionToList(ety cty.Type, conv conversion) conversion {
 			return cty.ListValEmpty(ety), nil
 		}
 
+		if !cty.CanListVal(elems) {
+			return cty.NilVal, fmt.Errorf("element types must all match for conversion to list")
+		}
+
 		return cty.ListVal(elems), nil
 	}
 }
@@ -94,6 +100,10 @@ func conversionCollectionToSet(ety cty.Type, conv conversion) conversion {
 				ety = val.Type().ElementType()
 			}
 			return cty.SetValEmpty(ety), nil
+		}
+
+		if !cty.CanSetVal(elems) {
+			return cty.NilVal, fmt.Errorf("element types must all match for conversion to set")
 		}
 
 		return cty.SetVal(elems), nil
@@ -152,8 +162,8 @@ func conversionCollectionToMap(ety cty.Type, conv conversion) conversion {
 			}
 		}
 
-		if err := conversionCheckMapElementTypes(elems, path); err != nil {
-			return cty.NilVal, err
+		if !cty.CanMapVal(elems) {
+			return cty.NilVal, fmt.Errorf("element types must all match for conversion to map")
 		}
 
 		return cty.MapVal(elems), nil
@@ -235,6 +245,10 @@ func conversionTupleToSet(tupleType cty.Type, setEty cty.Type, unsafe bool) conv
 			elems = append(elems, val)
 
 			i++
+		}
+
+		if !cty.CanSetVal(elems) {
+			return cty.NilVal, fmt.Errorf("element types must all match for conversion to set")
 		}
 
 		return cty.SetVal(elems), nil
@@ -324,6 +338,11 @@ func conversionTupleToList(tupleType cty.Type, listEty cty.Type, unsafe bool) co
 		if err != nil {
 			return cty.NilVal, err
 		}
+
+		if !cty.CanListVal(elems) {
+			return cty.NilVal, fmt.Errorf("element types must all match for conversion to list")
+		}
+
 		return cty.ListVal(elems), nil
 	}
 }
@@ -402,8 +421,8 @@ func conversionObjectToMap(objectType cty.Type, mapEty cty.Type, unsafe bool) co
 			}
 		}
 
-		if err := conversionCheckMapElementTypes(elems, path); err != nil {
-			return cty.NilVal, err
+		if !cty.CanMapVal(elems) {
+			return cty.NilVal, fmt.Errorf("attribute types must all match for conversion to map")
 		}
 
 		return cty.MapVal(elems), nil
@@ -487,7 +506,7 @@ func conversionUnifyCollectionElements(elems map[string]cty.Value, path cty.Path
 	}
 	unifiedType, _ := unify(elemTypes, unsafe)
 	if unifiedType == cty.NilType {
-		return nil, path.NewErrorf("collection elements cannot be unified")
+		return nil, path.NewErrorf("cannot find a common base type for all elements")
 	}
 
 	unifiedElems := make(map[string]cty.Value)
@@ -514,26 +533,6 @@ func conversionUnifyCollectionElements(elems map[string]cty.Value, path cty.Path
 	return unifiedElems, nil
 }
 
-func conversionCheckMapElementTypes(elems map[string]cty.Value, path cty.Path) error {
-	elementType := cty.NilType
-	elemPath := append(path.Copy(), nil)
-
-	for name, elem := range elems {
-		if elementType == cty.NilType {
-			elementType = elem.Type()
-			continue
-		}
-		if !elementType.Equals(elem.Type()) {
-			elemPath[len(elemPath)-1] = cty.IndexStep{
-				Key: cty.StringVal(name),
-			}
-			return elemPath.NewErrorf("%s is required", elementType.FriendlyName())
-		}
-	}
-
-	return nil
-}
-
 func conversionUnifyListElements(elems []cty.Value, path cty.Path, unsafe bool) ([]cty.Value, error) {
 	elemTypes := make([]cty.Type, len(elems))
 	for i, elem := range elems {
@@ -541,7 +540,7 @@ func conversionUnifyListElements(elems []cty.Value, path cty.Path, unsafe bool) 
 	}
 	unifiedType, _ := unify(elemTypes, unsafe)
 	if unifiedType == cty.NilType {
-		return nil, path.NewErrorf("collection elements cannot be unified")
+		return nil, path.NewErrorf("cannot find a common base type for all elements")
 	}
 
 	ret := make([]cty.Value, len(elems))

--- a/cty/value_init.go
+++ b/cty/value_init.go
@@ -186,6 +186,20 @@ func ListValEmpty(element Type) Value {
 	}
 }
 
+// CanListVal returns false if the given Values can not be coalesced
+// into a single List due to inconsistent element types.
+func CanListVal(vals []Value) bool {
+	elementType := DynamicPseudoType
+	for _, val := range vals {
+		if elementType == DynamicPseudoType {
+			elementType = val.ty
+		} else if val.ty != DynamicPseudoType && !elementType.Equals(val.ty) {
+			return false
+		}
+	}
+	return true
+}
+
 // MapVal returns a Value of a map type whose element type is defined by
 // the types of the given values, which must be homogenous.
 //
@@ -227,6 +241,20 @@ func MapValEmpty(element Type) Value {
 	}
 }
 
+// CanMapVal returns false if the given Values can not be coalesced into a
+// single Map due to inconsistent element types.
+func CanMapVal(vals map[string]Value) bool {
+	elementType := DynamicPseudoType
+	for _, val := range vals {
+		if elementType == DynamicPseudoType {
+			elementType = val.ty
+		} else if val.ty != DynamicPseudoType && !elementType.Equals(val.ty) {
+			return false
+		}
+	}
+	return true
+}
+
 // SetVal returns a Value of set type whose element type is defined by
 // the types of the given values, which must be homogenous.
 //
@@ -265,6 +293,26 @@ func SetVal(vals []Value) Value {
 		ty: Set(elementType),
 		v:  rawVal,
 	}.WithMarks(markSets...)
+}
+
+// CanSetVal returns false if the given Values can not be coalesced
+// into a single Set due to inconsistent element types.
+func CanSetVal(vals []Value) bool {
+	elementType := DynamicPseudoType
+	var markSets []ValueMarks
+
+	for _, val := range vals {
+		if unmarkedVal, marks := val.UnmarkDeep(); len(marks) > 0 {
+			val = unmarkedVal
+			markSets = append(markSets, marks)
+		}
+		if elementType == DynamicPseudoType {
+			elementType = val.ty
+		} else if val.ty != DynamicPseudoType && !elementType.Equals(val.ty) {
+			return false
+		}
+	}
+	return true
 }
 
 // SetValFromValueSet returns a Value of set type based on an already-constructed

--- a/cty/value_init_test.go
+++ b/cty/value_init_test.go
@@ -116,3 +116,319 @@ func TestSetVal_nestedStructures(t *testing.T) {
 		})
 	}
 }
+
+func TestCanListVal(t *testing.T) {
+	testCases := []struct {
+		Elems []Value
+		Want  bool
+	}{
+		// Valid lists
+		{
+			[]Value{StringVal("Hello"), StringVal("World")},
+			true,
+		},
+		{
+			[]Value{NumberIntVal(13), NumberIntVal(31)},
+			true,
+		},
+		{
+			[]Value{BoolVal(true), BoolVal(false)},
+			true,
+		},
+		{
+			[]Value{
+				ListVal([]Value{
+					StringVal("Hello"), StringVal("World"),
+				}),
+				ListVal([]Value{
+					StringVal("beep"), StringVal("boop"), StringVal("bloop"),
+				}),
+			},
+			true,
+		},
+		{
+			[]Value{
+				MapVal(map[string]Value{
+					"a": StringVal("Hello"),
+				}),
+				MapVal(map[string]Value{
+					"c": StringVal("World"),
+				}),
+			},
+			true,
+		},
+		{
+			[]Value{
+				SetVal([]Value{
+					StringVal("Hello"), StringVal("World"),
+				}),
+				SetVal([]Value{
+					StringVal("beep"), StringVal("boop"), StringVal("bloop"),
+				}),
+			},
+			true,
+		},
+		// invalid list elements
+		{
+			[]Value{StringVal("hello"), NumberIntVal(13)},
+			false,
+		},
+		{
+			[]Value{
+				ListVal([]Value{
+					StringVal("Hello"), StringVal("World"),
+				}),
+				MapVal(map[string]Value{
+					"a": StringVal("bloop"),
+				}),
+			},
+			false,
+		},
+		{ // List of string and List of lists
+			[]Value{
+				ListVal([]Value{
+					StringVal("Hello"), StringVal("World"),
+				}),
+				ListVal([]Value{
+					ListVal([]Value{
+						StringVal("a"), StringVal("b"),
+					}),
+					ListVal([]Value{
+						StringVal("c"), StringVal("d"),
+					}),
+				}),
+			},
+			false,
+		},
+		{ // Inconsistent map elements
+			[]Value{
+				MapVal(map[string]Value{
+					"a": StringVal("Hello"),
+				}),
+				MapVal(map[string]Value{
+					"a": BoolVal(true),
+				}),
+			},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		got := CanListVal(tc.Elems)
+		if got != tc.Want {
+			t.Errorf("wrong result for elements %#v:\ngot %v, want %v", tc.Elems, got, tc.Want)
+		}
+	}
+}
+
+func TestCanSetVal(t *testing.T) {
+	testCases := []struct {
+		Elems []Value
+		Want  bool
+	}{
+		// Valid set elements
+		{
+			[]Value{StringVal("Hello"), StringVal("World")},
+			true,
+		},
+		{
+			[]Value{StringVal("Hello").Mark(1), StringVal("World").Mark(2)},
+			true,
+		},
+		{
+			[]Value{NumberIntVal(13), NumberIntVal(31)},
+			true,
+		},
+		{
+			[]Value{BoolVal(true), BoolVal(false)},
+			true,
+		},
+		{
+			[]Value{
+				ListVal([]Value{
+					StringVal("Hello"), StringVal("World"),
+				}),
+				ListVal([]Value{
+					StringVal("beep"), StringVal("boop"), StringVal("bloop"),
+				}),
+			},
+			true,
+		},
+		{
+			[]Value{
+				MapVal(map[string]Value{
+					"a": StringVal("Hello"),
+				}),
+				MapVal(map[string]Value{
+					"c": StringVal("World"),
+				}),
+			},
+			true,
+		},
+		{
+			[]Value{
+				SetVal([]Value{
+					StringVal("Hello"), StringVal("World"),
+				}),
+				SetVal([]Value{
+					StringVal("beep"), StringVal("boop"), StringVal("bloop"),
+				}),
+			},
+			true,
+		},
+		// invalid set elements
+		{
+			[]Value{StringVal("hello"), NumberIntVal(13)},
+			false,
+		},
+		{
+			[]Value{
+				ListVal([]Value{
+					StringVal("Hello"), StringVal("World"),
+				}),
+				MapVal(map[string]Value{
+					"a": StringVal("bloop"),
+				}),
+			},
+			false,
+		},
+		{ // List of string and List of lists
+			[]Value{
+				ListVal([]Value{
+					StringVal("Hello"), StringVal("World"),
+				}),
+				ListVal([]Value{
+					ListVal([]Value{
+						StringVal("a"), StringVal("b"),
+					}),
+					ListVal([]Value{
+						StringVal("c"), StringVal("d"),
+					}),
+				}),
+			},
+			false,
+		},
+		{ // Inconsistent map elements
+			[]Value{
+				MapVal(map[string]Value{
+					"a": StringVal("Hello"),
+				}),
+				MapVal(map[string]Value{
+					"a": BoolVal(true),
+				}),
+			},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		got := CanSetVal(tc.Elems)
+		if got != tc.Want {
+			t.Errorf("wrong result for elements %#v:\ngot %v, want %v", tc.Elems, got, tc.Want)
+		}
+	}
+}
+
+func TestCanMapVal(t *testing.T) {
+	testCases := []struct {
+		Elems map[string]Value
+		Want  bool
+	}{
+		// Valid lists
+		{
+			map[string]Value{"a": StringVal("Hello"), "b": StringVal("World")},
+			true,
+		},
+		{
+			map[string]Value{"one": NumberIntVal(13), "two": NumberIntVal(31)},
+			true,
+		},
+		{
+			map[string]Value{"one": BoolVal(true), "two": BoolVal(false)},
+			true,
+		},
+		{
+			map[string]Value{
+				"lista": ListVal([]Value{
+					StringVal("Hello"), StringVal("World"),
+				}),
+				"listb": ListVal([]Value{
+					StringVal("beep"), StringVal("boop"), StringVal("bloop"),
+				}),
+			},
+			true,
+		},
+		{
+			map[string]Value{
+				"map_a": MapVal(map[string]Value{
+					"a": StringVal("Hello"),
+				}),
+				"map_b": MapVal(map[string]Value{
+					"c": StringVal("World"),
+				}),
+			},
+			true,
+		},
+		{
+			map[string]Value{
+				"set_a": SetVal([]Value{
+					StringVal("Hello"), StringVal("World"),
+				}),
+				"set_b": SetVal([]Value{
+					StringVal("beep"), StringVal("boop"), StringVal("bloop"),
+				}),
+			},
+			true,
+		},
+		// invalid map elements
+		{
+			map[string]Value{"one": StringVal("hello"), "two": NumberIntVal(13)},
+			false,
+		},
+		{
+			map[string]Value{
+				"one": ListVal([]Value{
+					StringVal("Hello"), StringVal("World"),
+				}),
+				"two": MapVal(map[string]Value{
+					"a": StringVal("bloop"),
+				}),
+			},
+			false,
+		},
+		{
+			map[string]Value{
+				"one": ListVal([]Value{
+					StringVal("Hello"), StringVal("World"),
+				}),
+				"two": ListVal([]Value{
+					ListVal([]Value{
+						StringVal("a"), StringVal("b"),
+					}),
+					ListVal([]Value{
+						StringVal("c"), StringVal("d"),
+					}),
+				}),
+			},
+			false,
+		},
+		{ // Inconsistent map elements
+			map[string]Value{
+				"one": MapVal(map[string]Value{
+					"a": StringVal("Hello"),
+				}),
+				"two": MapVal(map[string]Value{
+					"a": BoolVal(true),
+				}),
+			},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		got := CanMapVal(tc.Elems)
+		if got != tc.Want {
+			t.Errorf("wrong result for elements %#v:\ngot %v, want %v", tc.Elems, got, tc.Want)
+		}
+	}
+}


### PR DESCRIPTION
The logic which may result in a panic in List(), Map() and Set() have been extracted into these helper functions, which return errors instead. The original callers (still) panic if an error is returned.

These new functions are called in the appropriate conversion functions in the convert package to validate that the given elements can be used to create a single Type, to help reduce the number of panics that occur when calling Convert.

For additional background information on the (odd) scenarios that can lead to these panics, see https://github.com/hashicorp/terraform/issues/26195


While working on this, I realized that `conversionCheckMapElementTypes` was doing much the same thing, so I removed it in favor of `CanMapFunc()`. However since the logic for CanMapFunc() was taken from Map(), it's lost the path-specific error. If that's not good enough I can roll back its removal!