### PR TITLE
function/stdlib: ZipmapFunc precise mark handling

### DIFF
--- a/cty/marks.go
+++ b/cty/marks.go
@@ -180,6 +180,9 @@ func (val Value) Mark(mark interface{}) Value {
 		for k, v := range mr.marks {
 			newMarker.marks[k] = v
 		}
+		// unwrap the inner marked value, so we don't get multiple layers
+		// of marking.
+		newMarker.realV = mr.realV
 	} else {
 		// It's not a marker yet, so we're creating the first mark.
 		newMarker.marks = make(ValueMarks, 1)

--- a/cty/marks.go
+++ b/cty/marks.go
@@ -27,13 +27,31 @@ type marker struct {
 type ValueMarks map[interface{}]struct{}
 
 // NewValueMarks constructs a new ValueMarks set with the given mark values.
+//
+// If any of the arguments are already ValueMarks values then they'll be merged
+// into the result, rather than used directly as individual marks.
 func NewValueMarks(marks ...interface{}) ValueMarks {
 	if len(marks) == 0 {
 		return nil
 	}
 	ret := make(ValueMarks, len(marks))
 	for _, v := range marks {
+		if vm, ok := v.(ValueMarks); ok {
+			// Constructing a new ValueMarks with an existing ValueMarks
+			// implements a merge operation. (This can cause our result to
+			// have a larger size than we expected, but that's okay.)
+			for v := range vm {
+				ret[v] = struct{}{}
+			}
+			continue
+		}
 		ret[v] = struct{}{}
+	}
+	if len(ret) == 0 {
+		// If we were merging ValueMarks values together and they were all
+		// empty then we'll avoid returning a zero-length map and return a
+		// nil instead, as is conventional.
+		return nil
 	}
 	return ret
 }

--- a/cty/marks_test.go
+++ b/cty/marks_test.go
@@ -244,6 +244,15 @@ func TestMarks(t *testing.T) {
 		t.Fatalf("still marked after unmark: %#v", marks)
 	}
 	wantMarks(marks, "a", "b", "c")
+
+	// Multiple marks, applied separately
+	val = val.Mark("a").Mark("b")
+	wantMarks(val.Marks(), "a", "b")
+	val, marks = val.Unmark()
+	if val.IsMarked() {
+		t.Fatalf("still marked after unmark: %#v", marks)
+	}
+	wantMarks(marks, "a", "b")
 }
 
 func TestUnmarkDeep(t *testing.T) {

--- a/cty/value_ops.go
+++ b/cty/value_ops.go
@@ -492,18 +492,23 @@ func (val Value) RawEquals(other Value) bool {
 
 	case ty.IsMapType():
 		ety := ty.typeImpl.(typeMap).ElementTypeT
-		if len(val.v.(map[string]interface{})) == len(other.v.(map[string]interface{})) {
-			for k := range val.v.(map[string]interface{}) {
-				if _, ok := other.v.(map[string]interface{})[k]; !ok {
+		if !val.HasSameMarks(other) {
+			return false
+		}
+		valUn, _ := val.Unmark()
+		otherUn, _ := other.Unmark()
+		if len(valUn.v.(map[string]interface{})) == len(otherUn.v.(map[string]interface{})) {
+			for k := range valUn.v.(map[string]interface{}) {
+				if _, ok := otherUn.v.(map[string]interface{})[k]; !ok {
 					return false
 				}
 				lhs := Value{
 					ty: ety,
-					v:  val.v.(map[string]interface{})[k],
+					v:  valUn.v.(map[string]interface{})[k],
 				}
 				rhs := Value{
 					ty: ety,
-					v:  other.v.(map[string]interface{})[k],
+					v:  otherUn.v.(map[string]interface{})[k],
 				}
 				eq := lhs.RawEquals(rhs)
 				if !eq {

--- a/cty/value_ops_test.go
+++ b/cty/value_ops_test.go
@@ -1082,6 +1082,26 @@ func TestValueRawEquals(t *testing.T) {
 			true,
 		},
 		{
+			MapValEmpty(Number).Mark("a"),
+			MapValEmpty(Number).Mark("a"),
+			true,
+		},
+		{
+			MapValEmpty(Number).Mark("a"),
+			MapValEmpty(Number),
+			false,
+		},
+		{
+			MapValEmpty(Number),
+			MapValEmpty(Number).Mark("a"),
+			false,
+		},
+		{
+			MapValEmpty(Number).Mark("a"),
+			MapValEmpty(Number).Mark("a").Mark("b"),
+			false,
+		},
+		{
 			MapValEmpty(Number),
 			MapValEmpty(Bool),
 			false,


### PR DESCRIPTION
`ZipmapFunc` can now handle marks on an element-by-element basis, to the extent that the `cty` type system is able to do so.

Since map keys can't be individually sensitive, any sensitive values in the keys list will aggregate on the map as a whole, but the individual value elements will have their marks preserved individually.

We previously didn't have unit tests for `ZipmapFunc` so this also includes some additional tests not related to marks, in order to cover the other interesting cases this function must handle.

---

Writing the tests for this also exposed some bugs in the `cty` package's handling of marks, and so I've fixed them as additional commits here.
