### PR TITLE
function/stdlib: ConcatFunc precise handling of marks

### DIFF
--- a/cty/function/stdlib/sequence_test.go
+++ b/cty/function/stdlib/sequence_test.go
@@ -54,6 +54,54 @@ func TestConcat(t *testing.T) {
 					cty.NumberIntVal(1),
 				}),
 				cty.ListVal([]cty.Value{
+					cty.NumberIntVal(2),
+					cty.NumberIntVal(3),
+				}).Mark("a"),
+			},
+			cty.ListVal([]cty.Value{
+				cty.NumberIntVal(1),
+				cty.NumberIntVal(2),
+				cty.NumberIntVal(3),
+			}).Mark("a"),
+		},
+		{
+			[]cty.Value{
+				cty.ListVal([]cty.Value{
+					cty.NumberIntVal(1),
+				}),
+				cty.ListVal([]cty.Value{
+					cty.NumberIntVal(2).Mark("b"),
+					cty.NumberIntVal(3),
+				}),
+			},
+			cty.ListVal([]cty.Value{
+				cty.NumberIntVal(1),
+				cty.NumberIntVal(2).Mark("b"),
+				cty.NumberIntVal(3),
+			}),
+		},
+		{
+			[]cty.Value{
+				cty.ListVal([]cty.Value{
+					cty.NumberIntVal(1),
+				}).Mark("a"),
+				cty.ListVal([]cty.Value{
+					cty.NumberIntVal(2).Mark("b"),
+					cty.NumberIntVal(3),
+				}),
+			},
+			cty.ListVal([]cty.Value{
+				cty.NumberIntVal(1),
+				cty.NumberIntVal(2).Mark("b"),
+				cty.NumberIntVal(3),
+			}).Mark("a"),
+		},
+		{
+			[]cty.Value{
+				cty.ListVal([]cty.Value{
+					cty.NumberIntVal(1),
+				}),
+				cty.ListVal([]cty.Value{
 					cty.StringVal("foo"),
 				}),
 				cty.ListVal([]cty.Value{


### PR DESCRIPTION
`ConcatFunc` will now only mark the resulting list with marks from the argument lists as a whole, and not aggregate individual list element marks at the top-level result.

The individual element marks will still be preserved, but they'll remain attached to the individual element values they came from, avoiding the result as a whole becoming marked.