### PR TITLE
Merge, flatten, length, lookup functions: more precise handling of marks

### DIFF
--- a/cty/function/stdlib/collection.go
+++ b/cty/function/stdlib/collection.go
@@ -111,6 +111,7 @@ var LengthFunc = function.New(&function.Spec{
 			Name:             "collection",
 			Type:             cty.DynamicPseudoType,
 			AllowDynamicType: true,
+			AllowMarked:      true,
 		},
 	},
 	Type: func(args []cty.Value) (ret cty.Type, err error) {

--- a/cty/function/stdlib/collection_test.go
+++ b/cty/function/stdlib/collection_test.go
@@ -976,6 +976,20 @@ func TestLength(t *testing.T) {
 			cty.DynamicVal,
 			cty.UnknownVal(cty.Number),
 		},
+		{ // Marked collections return a marked length
+			cty.ListVal([]cty.Value{
+				cty.StringVal("hello"),
+				cty.StringVal("world"),
+			}).Mark("secret"),
+			cty.NumberIntVal(2).Mark("secret"),
+		},
+		{ // Marks on values in unmarked collections do not propagate
+			cty.ListVal([]cty.Value{
+				cty.StringVal("hello").Mark("a"),
+				cty.StringVal("world").Mark("b"),
+			}),
+			cty.NumberIntVal(2),
+		},
 	}
 
 	for _, test := range tests {

--- a/cty/function/stdlib/collection_test.go
+++ b/cty/function/stdlib/collection_test.go
@@ -1028,6 +1028,67 @@ func TestLookup(t *testing.T) {
 			cty.StringVal("nope"),
 			cty.StringVal("bar"),
 		},
+		{ // successful marked collection lookup returns marked value
+			cty.MapVal(map[string]cty.Value{
+				"boop": cty.StringVal("beep"),
+			}).Mark("a"),
+			cty.StringVal("boop"),
+			cty.StringVal("nope"),
+			cty.StringVal("beep").Mark("a"),
+		},
+		{ // apply collection marks to unknown return vaue
+			cty.MapVal(map[string]cty.Value{
+				"boop": cty.StringVal("beep"),
+				"frob": cty.UnknownVal(cty.String),
+			}).Mark("a"),
+			cty.StringVal("boop"),
+			cty.StringVal("nope"),
+			cty.UnknownVal(cty.String).Mark("a"),
+		},
+		{ // propagate collection marks to default when returning
+			cty.MapVal(map[string]cty.Value{
+				"boop": cty.StringVal("beep"),
+			}).Mark("a"),
+			cty.StringVal("frob"),
+			cty.StringVal("nope").Mark("b"),
+			cty.StringVal("nope").WithMarks(cty.NewValueMarks("a", "b")),
+		},
+		{ // on unmarked collection, return only marks from found value
+			cty.MapVal(map[string]cty.Value{
+				"boop": cty.StringVal("beep").Mark("a"),
+				"frob": cty.StringVal("honk").Mark("b"),
+			}),
+			cty.StringVal("frob"),
+			cty.StringVal("nope").Mark("c"),
+			cty.StringVal("honk").Mark("b"),
+		},
+		{ // on unmarked collection, return default exactly on missing
+			cty.MapVal(map[string]cty.Value{
+				"boop": cty.StringVal("beep").Mark("a"),
+				"frob": cty.StringVal("honk").Mark("b"),
+			}),
+			cty.StringVal("squish"),
+			cty.StringVal("nope").Mark("c"),
+			cty.StringVal("nope").Mark("c"),
+		},
+		{ // retain marks on default if converted
+			cty.MapVal(map[string]cty.Value{
+				"boop": cty.StringVal("beep").Mark("a"),
+				"frob": cty.StringVal("honk").Mark("b"),
+			}),
+			cty.StringVal("squish"),
+			cty.NumberIntVal(5).Mark("c"),
+			cty.StringVal("5").Mark("c"),
+		},
+		{ // propagate marks from key
+			cty.MapVal(map[string]cty.Value{
+				"boop": cty.StringVal("beep"),
+				"frob": cty.StringVal("honk"),
+			}),
+			cty.StringVal("boop").Mark("a"),
+			cty.StringVal("nope"),
+			cty.StringVal("beep").Mark("a"),
+		},
 	}
 
 	for _, test := range tests {

--- a/cty/function/stdlib/collection_test.go
+++ b/cty/function/stdlib/collection_test.go
@@ -769,6 +769,61 @@ func TestMerge(t *testing.T) {
 			cty.MapValEmpty(cty.String),
 			false,
 		},
+		{ // Preserve marks from chosen elements
+			[]cty.Value{
+				cty.MapVal(map[string]cty.Value{
+					"a": cty.StringVal("a").Mark("first"),
+					"c": cty.StringVal("c"),
+					"d": cty.StringVal("d").Mark("first"),
+				}),
+				cty.MapVal(map[string]cty.Value{
+					"a": cty.StringVal("a"),
+					"b": cty.StringVal("b").Mark("second"),
+					"c": cty.StringVal("c").Mark("second"),
+				}),
+			},
+			cty.MapVal(map[string]cty.Value{
+				"a": cty.StringVal("a"),
+				"b": cty.StringVal("b").Mark("second"),
+				"c": cty.StringVal("c").Mark("second"),
+				"d": cty.StringVal("d").Mark("first"),
+			}),
+			false,
+		},
+		{ // Marks on the collections must be merged, even if empty
+			[]cty.Value{
+				cty.MapVal(map[string]cty.Value{
+					"a": cty.StringVal("a"),
+				}).Mark("first"),
+				cty.MapVal(map[string]cty.Value{
+					"a": cty.StringVal("a"),
+					"b": cty.StringVal("b"),
+				}).Mark("second"),
+				cty.MapValEmpty(cty.String).Mark("third"),
+			},
+			cty.MapVal(map[string]cty.Value{
+				"a": cty.StringVal("a"),
+				"b": cty.StringVal("b"),
+			}).WithMarks(cty.NewValueMarks("first", "second", "third")),
+			false,
+		},
+		{ // Similar test but where all args are the same object type
+			[]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"a": cty.StringVal("a"),
+					"b": cty.NullVal(cty.String),
+				}).Mark("first"),
+				cty.ObjectVal(map[string]cty.Value{
+					"a": cty.StringVal("A"),
+					"b": cty.StringVal("B"),
+				}).Mark("second"),
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("A"),
+				"b": cty.StringVal("B"),
+			}).WithMarks(cty.NewValueMarks("first", "second")),
+			false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### function/stdlib: `MergeFunc` precise handling of marks

`MergeFunc` will now only mark the resulting map or object with marks from the given maps or objects as a whole, and not aggregate individual element/attribute marks at the top-level result.

The individual element/attribute marks will still be preserved, but they'll remain attached to the individual values they came from, avoiding the result as a whole becoming marked.

### function/stdlib: `FlattenFunc` precise handling of marks

`FlattenFunc` will now propagate marks from lists/sets/tuples which are flattened to the top level result. Marks on non-flattened elements are retained and not assigned to the resulting collection.

There is a significant change to the flattener helper function to ensure that marks are propagated from all nested lists/sets/tuples, even after first encountering an unknown collection. Previously finding an unknown collection allowed us to terminate early, but to preserve marks we need to continue to iterate through the rest of the arguments.

### function/stdlib: `LengthFunc` precise handling of marks

When taking the length of a marked collection, those marks should be preserved. Marks on individual elements should not propagate to the length result.

### function/stdlib: `LookupFunc` precise handling of marks

Several changes to `Lookup` to handle marks in a way that I think makes more sense:

- If the entire collection is marked, preserve the marks on any result (whether successful or fallback)
- If a returned value from the collection is marked, preserve the marks from only that value, combined with any overall collection marks
- Retain marks on the fallback value when it is returned, combined with any overall collection marks
- Disregard marks on the key value, as map keys and object attributes cannot be marked
- Retain collection marks when returning an unknown value for a not wholly-known collection
