### PR TITLE
Check each element for dynamic types in flatten

### DIFF
--- a/cty/function/stdlib/collection.go
+++ b/cty/function/stdlib/collection.go
@@ -530,16 +530,18 @@ func flattener(flattenList cty.Value) ([]cty.Value, []cty.ValueMarks, bool) {
 		// predict the length of our result yet either.
 		return nil, markses, false
 	}
-	// Any dynamic types could result in more collection that need to be
-	// flattened, so the type cannot be known.
-	if flattenList.Type().HasDynamicTypes() {
-		return nil, markses, false
-	}
 
 	out := make([]cty.Value, 0)
 	isKnown := true
 	for it := flattenList.ElementIterator(); it.Next(); {
 		_, val := it.Element()
+
+		// Any dynamic types could result in more collections that need to be
+		// flattened, so the type cannot be known.
+		if val.Type().Equals(cty.DynamicPseudoType) {
+			isKnown = false
+		}
+
 		if val.Type().IsListType() || val.Type().IsSetType() || val.Type().IsTupleType() {
 			if !val.IsKnown() {
 				isKnown = false

--- a/cty/function/stdlib/collection_test.go
+++ b/cty/function/stdlib/collection_test.go
@@ -1953,7 +1953,57 @@ func TestFlatten(t *testing.T) {
 					}).Mark("marked"),
 				}),
 			}),
-			cty.DynamicVal,
+			cty.DynamicVal.Mark("marked"),
+			"",
+		},
+		{
+			cty.TupleVal([]cty.Value{
+				cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"blop": cty.ListVal([]cty.Value{
+							cty.DynamicVal,
+						}),
+					}),
+				}),
+				cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bloop": cty.DynamicVal,
+					}),
+				}),
+			}),
+			cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"blop": cty.ListVal([]cty.Value{
+						cty.DynamicVal,
+					}),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"bloop": cty.DynamicVal,
+				}),
+			}),
+			"",
+		},
+		{
+			cty.ListVal([]cty.Value{
+				cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bloop": cty.DynamicVal,
+					}),
+				}),
+				cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"bloop": cty.DynamicVal,
+					}),
+				}),
+			}),
+			cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"bloop": cty.DynamicVal,
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"bloop": cty.DynamicVal,
+				}),
+			}),
 			"",
 		},
 		{


### PR DESCRIPTION
Using HasDynamicTypes to see if the Flatten argument's type will be
unknown is a little too conservative, and will also catch dynamic values
within maps and objects. Check each value as we're iterating to find any
dynamic values, relaxing the check imposed by #106.