### PR TITLE
concat may need to check length with marked vals

### DIFF
--- a/cty/function/stdlib/sequence.go
+++ b/cty/function/stdlib/sequence.go
@@ -43,6 +43,10 @@ var ConcatFunc = function.New(&function.Spec{
 
 		etys := make([]cty.Type, 0, len(args))
 		for i, val := range args {
+			// Discard marks for nested values, as we only need to handle types
+			// and lengths.
+			val, _ := val.UnmarkDeep()
+
 			ety := val.Type()
 			switch {
 			case ety.IsTupleType():

--- a/cty/function/stdlib/sequence_test.go
+++ b/cty/function/stdlib/sequence_test.go
@@ -98,6 +98,32 @@ func TestConcat(t *testing.T) {
 		},
 		{
 			[]cty.Value{
+				cty.ListValEmpty(cty.DynamicPseudoType).Mark("a"),
+				cty.ListVal([]cty.Value{
+					cty.NumberIntVal(2).Mark("b"),
+					cty.NumberIntVal(3),
+				}).Mark("c"),
+			},
+			cty.ListVal([]cty.Value{
+				cty.NumberIntVal(2).Mark("b"),
+				cty.NumberIntVal(3),
+			}).WithMarks(cty.NewValueMarks("a", "c")),
+		},
+		{
+			[]cty.Value{
+				cty.ListValEmpty(cty.DynamicPseudoType).Mark("a"),
+				cty.TupleVal([]cty.Value{
+					cty.NumberIntVal(2).Mark("b"),
+					cty.NumberIntVal(3),
+				}).Mark("c"),
+			},
+			cty.TupleVal([]cty.Value{
+				cty.NumberIntVal(2).Mark("b"),
+				cty.NumberIntVal(3),
+			}).WithMarks(cty.NewValueMarks("a", "c")),
+		},
+		{
+			[]cty.Value{
 				cty.ListVal([]cty.Value{
 					cty.NumberIntVal(1),
 				}),


### PR DESCRIPTION
If concat is building a tuple type, it will need to check the length of
the arguments which requires unmarking the values.