### PR TITLE
function/stdlib: Fix setproduct bug with unknowns

### DIFF
--- a/cty/function/stdlib/collection.go
+++ b/cty/function/stdlib/collection.go
@@ -948,18 +948,26 @@ var SetProductFunc = function.New(&function.Spec{
 		var retMarks cty.ValueMarks
 
 		total := 1
+		var hasUnknownLength bool
 		for _, arg := range args {
 			arg, marks := arg.Unmark()
 			retMarks = cty.NewValueMarks(retMarks, marks)
 
+			// Continue processing after we find an argument with unknown
+			// length to ensure that we cover all the marks
 			if !arg.Length().IsKnown() {
-				return cty.UnknownVal(retType).Mark(marks), nil
+				hasUnknownLength = true
+				continue
 			}
 
 			// Because of our type checking function, we are guaranteed that
 			// all of the arguments are known, non-null values of types that
 			// support LengthInt.
 			total *= arg.LengthInt()
+		}
+
+		if hasUnknownLength {
+			return cty.UnknownVal(retType).WithMarks(retMarks), nil
 		}
 
 		if total == 0 {

--- a/cty/function/stdlib/collection_test.go
+++ b/cty/function/stdlib/collection_test.go
@@ -2324,6 +2324,36 @@ func TestSetproduct(t *testing.T) {
 			}).Mark("b"),
 			``,
 		},
+		{
+			// Empty lists with marks should propagate the marks
+			[]cty.Value{
+				cty.ListValEmpty(cty.String).Mark("a"),
+				cty.ListValEmpty(cty.Bool).Mark("b"),
+			},
+			cty.ListValEmpty(cty.Tuple([]cty.Type{cty.String, cty.Bool})).WithMarks(cty.NewValueMarks("a", "b")),
+			``,
+		},
+		{
+			// Empty sets with marks should propagate the marks
+			[]cty.Value{
+				cty.SetValEmpty(cty.String).Mark("a"),
+				cty.SetValEmpty(cty.Bool).Mark("b"),
+			},
+			cty.SetValEmpty(cty.Tuple([]cty.Type{cty.String, cty.Bool})).WithMarks(cty.NewValueMarks("a", "b")),
+			``,
+		},
+		{
+			// Arguments which are sets with partially unknown values results
+			// in unknown length (since the unknown values may already be
+			// present in the set). This gives an unknown result preserving all
+			// marks
+			[]cty.Value{
+				cty.SetVal([]cty.Value{cty.StringVal("x"), cty.UnknownVal(cty.String)}).Mark("a"),
+				cty.SetVal([]cty.Value{cty.True, cty.False}).Mark("b"),
+			},
+			cty.UnknownVal(cty.Set(cty.Tuple([]cty.Type{cty.String, cty.Bool}))).WithMarks(cty.NewValueMarks("a", "b")),
+			``,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
If an argument to `setproduct` is a set with unknown values, its length is unknown, as the unknown values may be duplicates of others in the set. This should result in returning an unknown value propagating all marks.

Previously this crashed due to a misuse of `.Mark(marks)` instead of `.WithMarks(marks)`. This commit also fixes an issue with the previous logic, which would shortcut return and omit marks from any arguments after the set with unknown length.

Also includes a couple of tests for setproduct that were in my local working copy for some reason.

Downstream issue: https://github.com/hashicorp/terraform/issues/28984