### PR TITLE
flatten: only DynamicVal should cause flatten to become unknown, not a null dynamic value. 

### DIFF
--- a/cty/function/stdlib/collection.go
+++ b/cty/function/stdlib/collection.go
@@ -538,7 +538,7 @@ func flattener(flattenList cty.Value) ([]cty.Value, []cty.ValueMarks, bool) {
 
 		// Any dynamic types could result in more collections that need to be
 		// flattened, so the type cannot be known.
-		if val.Type().Equals(cty.DynamicPseudoType) && !val.IsNull() {
+		if val == cty.DynamicVal {
 			isKnown = false
 		}
 

--- a/cty/function/stdlib/collection.go
+++ b/cty/function/stdlib/collection.go
@@ -538,7 +538,7 @@ func flattener(flattenList cty.Value) ([]cty.Value, []cty.ValueMarks, bool) {
 
 		// Any dynamic types could result in more collections that need to be
 		// flattened, so the type cannot be known.
-		if val.Type().Equals(cty.DynamicPseudoType) {
+		if val.Type().Equals(cty.DynamicPseudoType) && !val.IsNull() {
 			isKnown = false
 		}
 

--- a/cty/function/stdlib/collection_test.go
+++ b/cty/function/stdlib/collection_test.go
@@ -2056,7 +2056,7 @@ func TestFlatten(t *testing.T) {
 					cty.StringVal("a"),
 					cty.StringVal("b"),
 				}),
-				cty.UnknownVal(cty.DynamicPseudoType),
+				cty.DynamicVal,
 				cty.TupleVal([]cty.Value{
 					cty.StringVal("c"),
 				}),

--- a/cty/function/stdlib/collection_test.go
+++ b/cty/function/stdlib/collection_test.go
@@ -2031,6 +2031,39 @@ func TestFlatten(t *testing.T) {
 			}),
 			"",
 		},
+		{
+			cty.TupleVal([]cty.Value{
+				cty.TupleVal([]cty.Value{
+					cty.StringVal("a"),
+					cty.StringVal("b"),
+				}),
+				cty.NullVal(cty.DynamicPseudoType),
+				cty.TupleVal([]cty.Value{
+					cty.StringVal("c"),
+				}),
+			}),
+			cty.TupleVal([]cty.Value{
+				cty.StringVal("a"),
+				cty.StringVal("b"),
+				cty.NullVal(cty.DynamicPseudoType),
+				cty.StringVal("c"),
+			}),
+			"",
+		},
+		{
+			cty.TupleVal([]cty.Value{
+				cty.TupleVal([]cty.Value{
+					cty.StringVal("a"),
+					cty.StringVal("b"),
+				}),
+				cty.UnknownVal(cty.DynamicPseudoType),
+				cty.TupleVal([]cty.Value{
+					cty.StringVal("c"),
+				}),
+			}),
+			cty.UnknownVal(cty.DynamicPseudoType),
+			"",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
When flattening a list of arguments, the special case of a `null` dynamic value should not force the result to be unknown. We do not check directly for "IsKnown" here, because it is specifically the dynamic type which will cause `flatten` to become unknown, while unknown values alone can be preserved preserved.

https://github.com/hashicorp/terraform/issues/29099