### PR TITLE
use big.Float for floor/ceil

### DIFF
--- a/cty/function/stdlib/number.go
+++ b/cty/function/stdlib/number.go
@@ -371,14 +371,21 @@ var CeilFunc = function.New(&function.Spec{
 	},
 	Type: function.StaticReturnType(cty.Number),
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
-		var val float64
-		if err := gocty.FromCtyValue(args[0], &val); err != nil {
-			return cty.UnknownVal(cty.String), err
+		f := args[0].AsBigFloat()
+
+		if f.IsInf() {
+			return cty.NumberVal(f), nil
 		}
-		if math.IsInf(val, 0) {
-			return cty.NumberFloatVal(val), nil
+
+		i, acc := f.Int(nil)
+		switch acc {
+		case big.Exact, big.Above:
+			// Done.
+		case big.Below:
+			i.Add(i, big.NewInt(1))
 		}
-		return cty.NumberIntVal(int64(math.Ceil(val))), nil
+
+		return cty.NumberVal(f.SetInt(i)), nil
 	},
 })
 
@@ -393,14 +400,21 @@ var FloorFunc = function.New(&function.Spec{
 	},
 	Type: function.StaticReturnType(cty.Number),
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
-		var val float64
-		if err := gocty.FromCtyValue(args[0], &val); err != nil {
-			return cty.UnknownVal(cty.String), err
+		f := args[0].AsBigFloat()
+
+		if f.IsInf() {
+			return cty.NumberVal(f), nil
 		}
-		if math.IsInf(val, 0) {
-			return cty.NumberFloatVal(val), nil
+
+		i, acc := f.Int(nil)
+		switch acc {
+		case big.Exact, big.Below:
+			// Done.
+		case big.Above:
+			i.Sub(i, big.NewInt(1))
 		}
-		return cty.NumberIntVal(int64(math.Floor(val))), nil
+
+		return cty.NumberVal(f.SetInt(i)), nil
 	},
 })
 

--- a/cty/function/stdlib/number_test.go
+++ b/cty/function/stdlib/number_test.go
@@ -817,6 +817,16 @@ func TestCeil(t *testing.T) {
 			cty.NumberFloatVal(math.Inf(-1)),
 			false,
 		},
+		{
+			cty.MustParseNumberVal("99999999999999999999999999999999999999999999999999998.123"),
+			cty.MustParseNumberVal("99999999999999999999999999999999999999999999999999999"),
+			false,
+		},
+		{
+			cty.MustParseNumberVal("-99999999999999999999999999999999999999999999999999998.123"),
+			cty.MustParseNumberVal("-99999999999999999999999999999999999999999999999999998"),
+			false,
+		},
 	}
 
 	for _, test := range tests {
@@ -863,6 +873,16 @@ func TestFloor(t *testing.T) {
 		{
 			cty.NumberFloatVal(math.Inf(-1)),
 			cty.NumberFloatVal(math.Inf(-1)),
+			false,
+		},
+		{
+			cty.MustParseNumberVal("99999999999999999999999999999999999999999999999999999.123"),
+			cty.MustParseNumberVal("99999999999999999999999999999999999999999999999999999"),
+			false,
+		},
+		{
+			cty.MustParseNumberVal("-99999999999999999999999999999999999999999999999999998.123"),
+			cty.MustParseNumberVal("-99999999999999999999999999999999999999999999999999999"),
 			false,
 		},
 	}


### PR DESCRIPTION
Do not convert floor and ceil arguments to float64 internally so as to not lose precision.

This leaves `pow` and `log` as the remaining numeric function which convert to primitive types internally. Both of these are much more complex to implement (which is why they are not included in the `math/big` package itself). The precision offered by `float64` ius likely sufficient for most any log operation, so that probably just leaves `exp` as the last function which needs to be implemented.