### PR TITLE
cty: handle deep marks in Equals

### DIFF
--- a/cty/value_ops.go
+++ b/cty/value_ops.go
@@ -116,9 +116,9 @@ func (val Value) GoString() string {
 // Use RawEquals to compare if two values are equal *ignoring* the
 // short-circuit rules and the exception for null values.
 func (val Value) Equals(other Value) Value {
-	if val.IsMarked() || other.IsMarked() {
-		val, valMarks := val.Unmark()
-		other, otherMarks := other.Unmark()
+	if val.ContainsMarked() || other.ContainsMarked() {
+		val, valMarks := val.UnmarkDeep()
+		other, otherMarks := other.UnmarkDeep()
 		return val.Equals(other).WithMarks(valMarks, otherMarks)
 	}
 

--- a/cty/value_ops_test.go
+++ b/cty/value_ops_test.go
@@ -753,6 +753,16 @@ func TestValueEquals(t *testing.T) {
 			StringVal("b").Mark(2),
 			False.WithMarks(NewValueMarks(1, 2)),
 		},
+
+		{
+			MapVal(map[string]Value{
+				"a": StringVal("a").Mark("boop"),
+			}),
+			MapVal(map[string]Value{
+				"a": StringVal("a").Mark("blop"),
+			}),
+			True.WithMarks(NewValueMarks("boop", "blop")),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Equals need to extract all marks from nested values, rather than just
the top level to avoid panicking during comparison.