### PR TITLE
cty: AsBigFloat does a shallow copy

### DIFF
--- a/cty/value_ops.go
+++ b/cty/value_ops.go
@@ -1283,9 +1283,7 @@ func (val Value) AsBigFloat() *big.Float {
 	}
 
 	// Copy the float so that callers can't mutate our internal state
-	ret := *(val.v.(*big.Float))
-
-	return &ret
+	return new(big.Float).Copy(val.v.(*big.Float))
 }
 
 // AsValueSlice returns a []cty.Value representation of a non-null, non-unknown

--- a/cty/value_ops_test.go
+++ b/cty/value_ops_test.go
@@ -3432,3 +3432,16 @@ func TestHasWhollyKnownType(t *testing.T) {
 		})
 	}
 }
+
+func TestFloatCopy(t *testing.T) {
+	// ensure manipulating floats does not modify the cty.Value
+	v := NumberFloatVal(1.9)
+	vString := v.GoString()
+
+	// do something that will modify the internal big.Float mantissa
+	v.AsBigFloat().SetInt64(1)
+
+	if vString != v.GoString() {
+		t.Fatalf("original value changed from %s to %#v", vString, v)
+	}
+}


### PR DESCRIPTION
Use `Float.Copy` in `AsBigFloat` to ensure that there is no shared data
between the mutable `*big.Float` and the `cty.Value` internal state.

Without the Copy, the given test will output:
```
original value changed from cty.NumberFloatVal(1.9) to cty.NumberIntVal(1)
```