### PR TITLE
formatlist: a DynamicVal arg may be a list

### DIFF
--- a/cty/function/stdlib/format.go
+++ b/cty/function/stdlib/format.go
@@ -114,6 +114,8 @@ var FormatListFunc = function.New(&function.Spec{
 					continue
 				}
 				iterators[i] = arg.ElementIterator()
+			case arg == cty.DynamicVal:
+				unknowns[i] = true
 			default:
 				singleVals[i] = arg
 			}

--- a/cty/function/stdlib/format_test.go
+++ b/cty/function/stdlib/format_test.go
@@ -836,6 +836,15 @@ func TestFormatList(t *testing.T) {
 			cty.UnknownVal(cty.List(cty.String)),
 			``,
 		},
+		23: {
+			cty.StringVal("%v"),
+			[]cty.Value{cty.DynamicVal},
+			// The current Function implementation will default to DynamicVal
+			// if AllowUnknown is true, even though this function has a static
+			// return type
+			cty.DynamicVal,
+			``,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
When formatlist encounters a DynamicVal argument, it must return an
unknown result, as it cannot determine if that will be a single value
argument resulting in an unknown string, or a list to be formatted into
an unknown number of strings.