### PR TITLE
feat: Adding support for u option for formatdate function

### DIFF
--- a/cty/function/stdlib/datetime.go
+++ b/cty/function/stdlib/datetime.go
@@ -189,6 +189,18 @@ var FormatDateFunc = function.New(&function.Spec{
 					default:
 						return cty.DynamicVal, function.NewArgErrorf(0, "invalid date format verb %q: timezone must be Z, ZZZZ, or ZZZZZ", tok)
 					}
+				case 'u':
+					if len(tok) == 1 {
+						d := t.Weekday()
+						dayOfWeekAsNum := int(d)
+						buf.WriteString(fmt.Sprint(dayOfWeekAsNum))
+					} else {
+						return cty.DynamicVal, function.NewArgErrorf(
+							0,
+							"invalid date format verb %q: day of week must be u",
+							tok,
+						)
+					}
 				default:
 					return cty.DynamicVal, function.NewArgErrorf(0, "invalid date format verb %q", tok)
 				}

--- a/cty/function/stdlib/datetime_test.go
+++ b/cty/function/stdlib/datetime_test.go
@@ -69,6 +69,11 @@ func TestFormatDate(t *testing.T) {
 			cty.StringVal("pm"),
 			``,
 		},
+		{
+			cty.StringVal("u"),
+			cty.StringVal("1"),
+			``,
+		},
 
 		// Some common standard machine-oriented formats
 		{
@@ -97,6 +102,11 @@ func TestFormatDate(t *testing.T) {
 			cty.StringVal("Y"),
 			cty.NilVal,
 			`invalid date format verb "Y": year must either be "YY" or "YYYY"`,
+		},
+		{
+			cty.StringVal("uu"),
+			cty.NilVal,
+			`invalid date format verb "uu": day of week must be u`,
 		},
 		{
 			cty.StringVal("YYYYY"),


### PR DESCRIPTION
@apparentlymart @jbardin 

feat: Adding support for `u` option for `formatdate` function. Ticket also mentions adding more options from `date` command, but I think those can be put in another ticket(s) (don't want to overload one issue or add command not being used). Please let me know if I'm missing anything for merging as I don't see a `CONTRIBUTING.md` file. Thanks!

Address [this issue from terraform](https://github.com/hashicorp/terraform/issues/29694)