### PR TITLE
Convert: error when trying to convert to the EmptyObject or the EmptyTuple types

### DIFF
--- a/cty/convert/conversion_capsule_test.go
+++ b/cty/convert/conversion_capsule_test.go
@@ -102,6 +102,18 @@ func TestConvertCapsuleType(t *testing.T) {
 			To:      cty.Bool,
 			WantErr: `bool required`,
 		},
+		{
+			From: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.StringVal("var"),
+			}),
+			To:      cty.EmptyObject,
+			WantErr: `incorrect object attributes`,
+		},
+		{
+			From:    cty.TupleVal([]cty.Value{cty.StringVal("foo")}),
+			To:      cty.EmptyTuple,
+			WantErr: `tuple required`,
+		},
 	}
 
 	for _, test := range tests {

--- a/cty/convert/public.go
+++ b/cty/convert/public.go
@@ -44,6 +44,12 @@ func Convert(in cty.Value, want cty.Type) (cty.Value, error) {
 		return in, nil
 	}
 
+	if want.Equals(cty.EmptyObject) || want.Equals(cty.EmptyTuple) {
+		// error when trying to convert `{"foo": "bar"}` to the empty type
+		// instead of returning `{}`.
+		return cty.NilVal, errors.New(MismatchMessage(in.Type(), want))
+	}
+
 	conv := GetConversionUnsafe(in.Type(), want)
 	if conv == nil {
 		return cty.NilVal, errors.New(MismatchMessage(in.Type(), want))


### PR DESCRIPTION
Without this change, converting an object to an empty object will return an empty object. Which silently loses data.

Would this be a correct thing to do ? Or should this type of validation be done from the user side ? Are there any cases where this would be preferable to let the conversion happen ?