### PR TITLE
Sanity check signs of raw number before comparison

### DIFF
--- a/cty/primitive_type.go
+++ b/cty/primitive_type.go
@@ -74,6 +74,8 @@ func rawNumberEqual(a, b *big.Float) bool {
 		return false
 	case a == nil: // b == nil too then, due to previous case
 		return true
+	case a.Sign() != b.Sign():
+		return false
 	default:
 		// This format and precision matches that used by cty/json.Marshal,
 		// and thus achieves our definition of "two numbers are equal if


### PR DESCRIPTION
This fixes a performance issue when comparing large numbers to zero (or large positive numbers to large negative numbers). Without this check, the numbers are both converted to text, and string compared, which is costly if the numbers are large.

This patch provides a cheap early-exit option if the signs don't match, speeding up the cost of comparison to zero. As part of this, the .Modulo function calling .RawEquals [here](https://github.com/zclconf/go-cty/blob/main/cty/value_ops.go#L690-L692) should also have significantly improved performance (which was otherwise an expensive check for large numbers).