### PR TITLE
fix typo causing a panic in tuple unification

### DIFF
--- a/cty/convert/unify.go
+++ b/cty/convert/unify.go
@@ -447,7 +447,6 @@ func unifyTupleTypes(types []cty.Type, unsafe bool, hasDynamic bool) (cty.Type, 
 			conversions[i] = GetConversion(ty, retTy)
 		}
 		if conversions[i] == nil {
-			// Shouldn't be reachable, since we were able to unify
 			return unifyTupleTypesToList(types, unsafe)
 		}
 	}
@@ -483,8 +482,8 @@ func unifyTupleTypesToList(types []cty.Type, unsafe bool) (cty.Type, []Conversio
 			conversions[i] = GetConversion(ty, retTy)
 		}
 		if conversions[i] == nil {
-			// Shouldn't be reachable, since we were able to unify
-			return unifyObjectTypesToMap(types, unsafe)
+			// no conversion was found
+			return cty.NilType, nil
 		}
 	}
 	return retTy, conversions

--- a/cty/convert/unify_test.go
+++ b/cty/convert/unify_test.go
@@ -164,6 +164,23 @@ func TestUnify(t *testing.T) {
 			[]bool{true, true},
 		},
 		{
+			// The second tuple value could be anything, so we can't unify
+			// these as a list.
+			// FIXME: While a unification is possible, we get a NilType for
+			// now until we can handle more complex recursive unification.
+			[]cty.Type{
+				cty.Tuple([]cty.Type{
+					cty.Object(map[string]cty.Type{
+						"a": cty.String,
+					}),
+					cty.DynamicPseudoType,
+				}),
+				cty.List(cty.DynamicPseudoType),
+			},
+			cty.NilType,
+			nil,
+		},
+		{
 			// unifies to the same result as above, since the only difference
 			// is the addition of a list
 			[]cty.Type{


### PR DESCRIPTION
The `unifyObjectTypesToMap` function was inadvertently called from the tuple-list unification function, which would panic since the value has no attributes.

The given test example is possible to speculatively unify, however we don't have a codepath to recursively unify these yet, so we will just fail to unify for now. This will fix the crashes in downstream consumers, allowing the possibility of working around the shortcoming by using more specific or different combinations of types.