### PR TITLE
Security vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/apparentlymart/go-textseg/v13 v13.0.0
 	github.com/google/go-cmp v0.3.1
 	github.com/vmihailenco/msgpack/v4 v4.3.12
-	golang.org/x/text v0.3.5
+	golang.org/x/text v0.3.7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
-golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
-golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=


### PR DESCRIPTION
Request to update text library to non-vulnerable version v0.3.7. [CVE-2021-38561](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-38561)


Description from CVE
golang-x-text - Out-of-bounds Read
Explanation
The golang.org/x/text package is vulnerable due to an Out-of-bounds Read. The files and functions listed below do not properly handle index calculations when parsing formatted language tags. A remote attacker can exploit this behavior by supplying a specially-crafted language tag to trigger a panic, causing an application crash and ultimately a Denial of Service (DoS) condition.

Vulnerable File(s) and Function(s):

internal/language/language.go

ParseExtension()
ParseBase()
ParseScript()
ParseRegion()
ParseVariant()
internal/language/parse.go

Parse()
language/parse.go

Parse()
Compose()
ParseAcceptLanguage()

