### PR TITLE
fix: return friendly name for nil type

### DIFF
--- a/cty/type.go
+++ b/cty/type.go
@@ -44,6 +44,10 @@ func (t Type) Equals(other Type) bool {
 
 // FriendlyName returns a human-friendly *English* name for the given type.
 func (t Type) FriendlyName() string {
+	if t.typeImpl == nil {
+		return "nil"
+	}
+
 	return t.typeImpl.FriendlyName(friendlyTypeName)
 }
 

--- a/cty/type_test.go
+++ b/cty/type_test.go
@@ -248,3 +248,37 @@ func TestTypeGoString(t *testing.T) {
 		})
 	}
 }
+
+func TestTypeFriendlyName(t *testing.T) {
+	tests := []struct {
+		Type Type
+		Want string
+	}{
+		{
+			String,
+			`string`,
+		},
+		{
+			Number,
+			`number`,
+		},
+		{
+			Bool,
+			`bool`,
+		},
+		{
+			NilType,
+			`nil`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Type.GoString(), func(t *testing.T) {
+			got := test.Type.FriendlyName()
+			want := test.Want
+			if got != want {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes issue where `cty.NilType` panics when calling `FriendlyName`.

This solves issues in the main https://github.com/hashicorp/hcl repo where diagnostics panic when trying to display a friendly message. 

For example, if a `ConditionalExpr` uses incompatible types `cty.NilType` and `cty.StringType` then `describeConditionalTypeMismatch` function will panic as `NilType` has no `typeImpl` set. i.e. on these lines: https://github.com/hashicorp/hcl/blob/88ecd1315610ac2c14d5dba8de0a25e75cdd4a58/hclsyntax/expression.go#L884-L885 . 

FYI I've only chosen to implement the `FriendlyName` method for the `cty.NilType`; however, there are other methods that I could see as problematic when using `cty.NilType`. I've noticed that the godoc mentions:

```
// NilType is an invalid type used when a function is returning an error
// and has no useful type to return. It should not be used, and any methods
// called on it will panic.
```

So I wanted to open this PR with these small changes and see if there is scope to make `cty.NilType` a "safer" type.