### PR TITLE
`convert`: Remove nested optional attributes when converting empty lists and sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.11.1 (Unreleased)
 
+* `convert`: Fix for error when converting empty sets and lists with nested optional attributes by explicitly removing optional attribute information from collections.
 
 # 1.11.0 (August 22, 2022)
 

--- a/cty/convert/conversion_collection.go
+++ b/cty/convert/conversion_collection.go
@@ -50,7 +50,7 @@ func conversionCollectionToList(ety cty.Type, conv conversion) conversion {
 			if ety == cty.DynamicPseudoType {
 				return cty.ListValEmpty(val.Type().ElementType()), nil
 			}
-			return cty.ListValEmpty(ety), nil
+			return cty.ListValEmpty(ety.WithoutOptionalAttributesDeep()), nil
 		}
 
 		if !cty.CanListVal(elems) {
@@ -99,7 +99,7 @@ func conversionCollectionToSet(ety cty.Type, conv conversion) conversion {
 			if ety == cty.DynamicPseudoType {
 				return cty.SetValEmpty(val.Type().ElementType()), nil
 			}
-			return cty.SetValEmpty(ety), nil
+			return cty.SetValEmpty(ety.WithoutOptionalAttributesDeep()), nil
 		}
 
 		if !cty.CanSetVal(elems) {

--- a/cty/convert/public_test.go
+++ b/cty/convert/public_test.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/zclconf/go-cty/cty"
@@ -988,6 +989,114 @@ func TestConvert(t *testing.T) {
 				cty.NullVal(cty.DynamicPseudoType),
 				cty.NullVal(cty.DynamicPseudoType),
 			}),
+			WantError: false,
+		},
+		{
+			Value: cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"xs": cty.ListVal([]cty.Value{
+						cty.ObjectVal(map[string]cty.Value{
+							"x": cty.NumberVal(big.NewFloat(1234)),
+						}),
+					}),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"xs": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+						"x": cty.Number,
+					})),
+				})},
+			),
+			Type: cty.List(cty.Object(map[string]cty.Type{
+				"xs": cty.List(cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+					"x": cty.Number,
+				}, []string{"x"})),
+			})),
+			Want: cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"xs": cty.ListVal([]cty.Value{
+						cty.ObjectVal(map[string]cty.Value{
+							"x": cty.NumberVal(big.NewFloat(1234)),
+						}),
+					}),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"xs": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+						"x": cty.Number,
+					})),
+				})},
+			),
+			WantError: false,
+		},
+		{
+			Value: cty.SetVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"xs": cty.SetVal([]cty.Value{
+						cty.ObjectVal(map[string]cty.Value{
+							"x": cty.NumberVal(big.NewFloat(1234)),
+						}),
+					}),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"xs": cty.SetValEmpty(cty.Object(map[string]cty.Type{
+						"x": cty.Number,
+					})),
+				})},
+			),
+			Type: cty.Set(cty.Object(map[string]cty.Type{
+				"xs": cty.Set(cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+					"x": cty.Number,
+				}, []string{"x"})),
+			})),
+			Want: cty.SetVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"xs": cty.SetVal([]cty.Value{
+						cty.ObjectVal(map[string]cty.Value{
+							"x": cty.NumberVal(big.NewFloat(1234)),
+						}),
+					}),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"xs": cty.SetValEmpty(cty.Object(map[string]cty.Type{
+						"x": cty.Number,
+					})),
+				})},
+			),
+			WantError: false,
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"foo": cty.ObjectVal(map[string]cty.Value{
+					"xs": cty.MapVal(map[string]cty.Value{
+						"nested_foo": cty.ObjectVal(map[string]cty.Value{
+							"x": cty.NumberVal(big.NewFloat(1234)),
+						}),
+					}),
+				}),
+				"bar": cty.ObjectVal(map[string]cty.Value{
+					"xs": cty.MapValEmpty(cty.Object(map[string]cty.Type{
+						"x": cty.Number,
+					})),
+				})},
+			),
+			Type: cty.Map(cty.Object(map[string]cty.Type{
+				"xs": cty.Map(cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+					"x": cty.Number,
+				}, []string{"x"})),
+			})),
+			Want: cty.MapVal(map[string]cty.Value{
+				"foo": cty.ObjectVal(map[string]cty.Value{
+					"xs": cty.MapVal(map[string]cty.Value{
+						"nested_foo": cty.ObjectVal(map[string]cty.Value{
+							"x": cty.NumberVal(big.NewFloat(1234)),
+						}),
+					}),
+				}),
+				"bar": cty.ObjectVal(map[string]cty.Value{
+					"xs": cty.MapValEmpty(cty.Object(map[string]cty.Type{
+						"x": cty.Number,
+					})),
+				})},
+			),
 			WantError: false,
 		},
 	}


### PR DESCRIPTION
For https://github.com/hashicorp/terraform/issues/31924

This PR makes the `Convert` function explicitly strip out any nested optional attributes from empty lists and sets as they are converted.

I added three unit tests, one each for `list`, `set` and `map`. Interestingly, `map` conversion works even without the change applied. I wonder if there's something else about the way maps work that means they're not affected by this. I've left the unit test in but haven't made any change to the `map` logic.