### PR TITLE
Introduce description field for function & parameters

### DIFF
--- a/cty/function/argument.go
+++ b/cty/function/argument.go
@@ -10,6 +10,9 @@ type Parameter struct {
 	// value, but callers may use it for documentation, etc.
 	Name string
 
+	// Description is an optional description for the argument.
+	Description string
+
 	// A type that any argument for this parameter must conform to.
 	// cty.DynamicPseudoType can be used, either at top-level or nested
 	// in a parameterized type, to indicate that any type should be

--- a/cty/function/function.go
+++ b/cty/function/function.go
@@ -14,6 +14,9 @@ type Function struct {
 // Spec is the specification of a function, used to instantiate
 // a new Function.
 type Spec struct {
+	// Description is an optional description for the function specification.
+	Description string
+
 	// Params is a description of the positional parameters for the function.
 	// The standard checking logic rejects any calls that do not provide
 	// arguments conforming to this definition, freeing the function
@@ -343,4 +346,9 @@ func (f Function) VarParam() *Parameter {
 
 	ret := *f.spec.VarParam
 	return &ret
+}
+
+// Description returns a human-readable description of the function.
+func (f Function) Description() string {
+	return f.spec.Description
 }


### PR DESCRIPTION
This PR introduces a new field, `Description`, to the functions `Spec` and `Parameter` types. I've decoupled this from the actual backfilling of all descriptions, so we and the education team can iterate on the descriptions.

## Background
To be able to offer auto-completion of available functions and their signatures within the Terraform language server, we need a longer description for both a function and each parameter.

More information is available in the [TF-418: Support Functions in Language Server](https://docs.google.com/document/d/1ZAzEjEefop5NpyP-npKgtr_zj7xIsNxT_KMheZPphdc/edit) RFC.

## Next Steps
* https://github.com/zclconf/go-cty/pull/136 backfills all the function & parameter descriptions for stdlib functions from `go-cty`
* After this PR gets merged, I plan to do a similar thing for the functions in TF core