### PR TITLE
Allow maps to convert into objects when missing optional attributes are not compatible

### DIFF
--- a/cty/convert/public_test.go
+++ b/cty/convert/public_test.go
@@ -994,6 +994,79 @@ func TestConvert(t *testing.T) {
 			}),
 		},
 		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"a": cty.StringVal("boop"),
+				// It's okay to use a map of string to convert to this
+				// target type as long as the source map does not include
+				// any of the optional attributes that cannot be assigned
+				// from a string.
+			}),
+			Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+				"a": cty.String,
+				"b": cty.String,
+				"c": cty.Object(map[string]cty.Type{
+					"d": cty.String,
+				}),
+			}, []string{"b", "c"}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("boop"),
+				"b": cty.NullVal(cty.String),
+				"c": cty.NullVal(cty.Object(map[string]cty.Type{
+					"d": cty.String,
+				})),
+			}),
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"a": cty.StringVal("boop"),
+			}),
+			Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+				"a": cty.String,
+				"b": cty.String,
+				"c": cty.Object(map[string]cty.Type{
+					"d": cty.DynamicPseudoType,
+				}),
+			}, []string{"b", "c"}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("boop"),
+				"b": cty.NullVal(cty.String),
+				"c": cty.NullVal(cty.Object(map[string]cty.Type{
+					"d": cty.DynamicPseudoType,
+				})),
+			}),
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"a": cty.StringVal("boop"),
+			}),
+			Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+				"a": cty.String,
+				"b": cty.String,
+				"c": cty.DynamicPseudoType,
+			}, []string{"b", "c"}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("boop"),
+				"b": cty.NullVal(cty.String),
+				"c": cty.NullVal(cty.DynamicPseudoType),
+			}),
+		},
+		{
+			Value: cty.MapVal(map[string]cty.Value{
+				"a": cty.StringVal("boop"),
+				// This case is invalid, because an element of a map of
+				// string cannot be assigned to an object-typed attribute.
+				"c": cty.StringVal("foobar"),
+			}),
+			Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+				"a": cty.String,
+				"b": cty.String,
+				"c": cty.Object(map[string]cty.Type{
+					"d": cty.String,
+				}),
+			}, []string{"b", "c"}),
+			WantError: `map element type is incompatible with attribute "c": object required`,
+		},
+		{
 			Value: cty.ListVal([]cty.Value{
 				cty.ObjectVal(map[string]cty.Value{
 					"xs": cty.ListVal([]cty.Value{


### PR DESCRIPTION
## Before this PR

When converting a map into an object, if any attributes/values were not compatible the whole conversion would fail.

## After this PR

If an attribute is not convertible then we check if it's optional. If it is optional, then we don't error right away. We record a nil converter for that attribute leaving us with three cases for each attribute:

1. No entry in the converters map at all, this means no conversion necessary (eg. string to string)
2. Non-nil entry in the converters map, this means a conversion is required but possible (eg. string to number)
3. Nil entry in the converters map, this means a conversion is required but not possible (eg. string to object)

Case 1 and Case 2 are covered already, and case 3 is introduced by this PR. Case 3 is only possible when we have found an optional attribute that is not convertible (we fail early if an attribute is required but not convertible). If we encounter case 3 during the conversion, it means an optional attribute that is not convertible is actually present in the map, so we fail at this point. If case 3 is never encountered then it means the map didn't actually contain any of these optional attributes so we can just set null values for them and still have a successful conversion.