### PR TITLE
deps: bump golang.org/x/text to 0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/apparentlymart/go-textseg/v13 v13.0.0
 	github.com/google/go-cmp v0.3.1
 	github.com/vmihailenco/msgpack/v4 v4.3.12
-	golang.org/x/text v0.3.7
+	golang.org/x/text v0.6.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.6.0 h1:3XmdazWV+ubf7QgHSTWeykHOci5oeekaGJBLkrkaw4k=
+golang.org/x/text v0.6.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=


### PR DESCRIPTION
The new version 0.6.0 fixed https://pkg.go.dev/vuln/GO-2022-1059

It is worth noting however that AFAICT `go-cty` is _not_ affected by this vulnerability, since it only uses `golang.org/x/text/unicode/norm` package in https://github.com/zclconf/go-cty/blob/1384f8d8c5d747275c9686ab9829b30c78189ecc/cty/value_init.go#L8 from this library. i.e. it does not use [MatchStrings](https://pkg.go.dev/golang.org/x/text/language#MatchStrings) nor
[ParseAcceptLanguage](https://pkg.go.dev/golang.org/x/text/language#ParseAcceptLanguage).

Therefore this merely reduces any possible noise from vulnerability scanners downstream.