### PR TITLE
Add a note for CanIterateElements about unknown and null

### DIFF
--- a/cty/value_ops.go
+++ b/cty/value_ops.go
@@ -1198,8 +1198,9 @@ func (val Value) ElementIterator() ElementIterator {
 	return elementIterator(val)
 }
 
-// CanIterateElements returns true if the receiver can support the
+// CanIterateElements returns true if the receiver type can support the
 // ElementIterator method (and by extension, ForEachElement) without panic.
+// Note this method will panic if the receiver is Unknown or null.
 func (val Value) CanIterateElements() bool {
 	return canElementIterator(val)
 }


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-ruleset-aws/pull/517#discussion_r1268169565
See also https://github.com/terraform-linters/tflint-ruleset-aws/issues/528#issuecomment-1667906280

The documentation for `CanIterateElements` says "return true if  the receiver can support  the ElementIterator method without panic", but it actually causes panic if unknown or null.

One way would be to fix the implementation to match the documentation, but that would probably be too much of an impact. This PR fixes the documentation to match the implementation and avoid making the same mistakes.