### PR TITLE
msgpack: truncate long string prefix refinements

### DIFF
--- a/cty/ctystrings/prefix.go
+++ b/cty/ctystrings/prefix.go
@@ -26,10 +26,6 @@ import (
 // application can guarantee that the remainder of the string will not begin
 // with combining marks then it is safe to instead just normalize the prefix
 // string with [Normalize].
-//
-// Note that this function only takes into account normalization boundaries
-// and does _not_ take into account grapheme cluster boundaries as defined
-// by Unicode Standard Annex #29.
 func SafeKnownPrefix(prefix string) string {
 	prefix = Normalize(prefix)
 


### PR DESCRIPTION
Serialising an unknown value with a string prefix refinement with a sufficiently long prefix will result in an error on deserialisation, since cty limits the size of the refinements blob to 1024 bytes.

This PR is an implementation of the approach described in https://github.com/hashicorp/terraform/issues/33464#issuecomment-1625670378 for getting around this. Of course we would have to truncate the value while deserialising as well, otherwise the value does not round-trip correctly.

@apparentlymart I'm assuming that we don't want to impose a limit on prefix length when constructing the refinement in the first place (nor does the RefinementBuilder seem to allow for this, as far as I can tell). Silently truncating the prefix during serialisation seems like it suffices to preserve "approximations of refinements" under msgpack as [documented](https://github.com/zclconf/go-cty/blob/main/docs/refinements.md#refinements-under-serialization), but if we really believe there is no proper use case for string prefix refinements greater than 256 bytes, can we let the consumer know more explicitly?