### PR TITLE
cty: WithoutOptionalAttributesDeep does not panic on cty.NilType

### DIFF
--- a/cty/type.go
+++ b/cty/type.go
@@ -120,7 +120,7 @@ func (t Type) HasDynamicTypes() bool {
 // object types. This operation is applied recursively.
 func (t Type) WithoutOptionalAttributesDeep() Type {
 	switch {
-	case t == DynamicPseudoType, t.IsPrimitiveType(), t.IsCapsuleType():
+	case t == DynamicPseudoType, t == NilType, t.IsPrimitiveType(), t.IsCapsuleType():
 		return t
 	case t.IsMapType():
 		return Map(t.ElementType().WithoutOptionalAttributesDeep())

--- a/cty/type_test.go
+++ b/cty/type_test.go
@@ -65,6 +65,10 @@ func TestWithoutOptionalAttributesDeep(t *testing.T) {
 			DynamicPseudoType,
 		},
 		{
+			NilType,
+			NilType,
+		},
+		{
 			List(DynamicPseudoType),
 			List(DynamicPseudoType),
 		},


### PR DESCRIPTION
Fix an issue where `WithoutOptionalAttributesDeep()` on a `cty.NilType` would result in a panic. This was discovered when using `gohcl` to decode a block that has attributes that are set to null.

```
panic: WithoutOptionalAttributesDeep does not support the given type

goroutine 46 [running]:
github.com/zclconf/go-cty/cty.Type.WithoutOptionalAttributesDeep({{0x0?, 0x0?}})
  ¦ ¦ ¦ /home/runner/go/pkg/mod/github.com/zclconf/go-cty@v1.14.0/cty/type.go:152 +0x565
github.com/zclconf/go-cty/cty/convert.conversionObjectToObject.func1({{{0x197f548?, 0xc0006ff170?}}, {0x1766d40?, 0xc0005b9da0?}}, {0x0, 0x0, 0x0})
  ¦ ¦ ¦ /home/runner/go/pkg/mod/github.com/zclconf/go-cty@v1.14.0/cty/convert/conversion_object.go:86 +0x3a5
github.com/zclconf/go-cty/cty/convert.getConversion.func1({{{0x197f548?, 0xc0006ff170?}}, {0x1766d40?, 0xc0005b9da0?}}, {0x0, 0x0, 0x0})
  ¦ ¦ ¦ /home/runner/go/pkg/mod/github.com/zclconf/go-cty@v1.14.0/cty/convert/conversion.go:57 +0x2b3
github.com/zclconf/go-cty/cty/convert.GetConversionUnsafe.retConversion.func1({{{0x197f548?, 0xc0006ff170?}}, {0x1766d40?, 0xc0005b9da0?}})
  ¦ ¦ ¦ /home/runner/go/pkg/mod/github.com/zclconf/go-cty@v1.14.0/cty/convert/conversion.go:199 +0x34
github.com/zclconf/go-cty/cty/convert.Convert({{{0x197f548?, 0xc0006ff170?}}, {0x1766d40?, 0xc0005b9da0?}}, {{0x197f548?, 0xc0006288b0?}})
  ¦ ¦ ¦ /home/runner/go/pkg/mod/github.com/zclconf/go-cty@v1.14.0/cty/convert/public.go:51 +0x151
github.com/hashicorp/hcl/v2/gohcl.DecodeExpression({0x197f698, 0xc0003b27e0}, 0x197f580?, {0x1720c40, 0xc0001cdcf8})
  ¦ ¦ ¦ /home/runner/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.18.0/gohcl/decode.go:299 +0xb0
github.com/hashicorp/enos/internal/flightplan.(*Scenario).decodeAndValidateTerraformCLIAttribute(0xc0001cdce0, 0xc0000cac00, 0xc001ac7998)
  ¦ ¦ ¦ /home/runner/actions-runner/_work/enos/enos/internal/flightplan/scenario.go:349 +0x610
github.com/hashicorp/enos/internal/flightplan.(*Scenario).decode(...)
  ¦ ¦ ¦ /home/runner/actions-runner/_work/enos/enos/internal/flightplan/scenario.go:187
github.com/hashicorp/enos/internal/flightplan.(*ScenarioDecoder).decodeScenario(0xc0005b36c8, 0xc000bc8bd0, 0xc00085cf70)
panic: WithoutOptionalAttributesDeep does not support the given type
```