### PR TITLE
cty: Value.Range should ignore marks

### DIFF
--- a/cty/value_range.go
+++ b/cty/value_range.go
@@ -21,6 +21,10 @@ import (
 // offered by ranges and so can share code between both known and unknown
 // values.
 func (v Value) Range() ValueRange {
+	// The value range makes no use of marks. Remove them now to simplify the
+	// logic below.
+	v, _ = v.Unmark()
+
 	// For an unknown value we just use its own refinements.
 	if unk, isUnk := v.v.(*unknownType); isUnk {
 		refinement := unk.refinement


### PR DESCRIPTION
This fixes a panic when calling `Range` with a marked unknown string. Since the string is marked, it fails the `unknownType` type assertion on line 29, and then the call to `AsString()` on line 57 panics because `AsString` assumes the value is known.

The simplest fix for this is to simply unmark the value at the beginning of the function, since `ValueRange` makes no use of marks, and a caller making use of both value ranges and marks will retain the original value for any processing of marks.