### PR TITLE
include NilType in .WithoutOptionalAttributesDeep

### DIFF
--- a/cty/type.go
+++ b/cty/type.go
@@ -1,5 +1,7 @@
 package cty
 
+import "fmt"
+
 // Type represents value types within the type system.
 //
 // This is a closed interface type, meaning that only the concrete
@@ -120,6 +122,8 @@ func (t Type) HasDynamicTypes() bool {
 // object types. This operation is applied recursively.
 func (t Type) WithoutOptionalAttributesDeep() Type {
 	switch {
+	case t == NilType:
+		return t
 	case t == DynamicPseudoType, t.IsPrimitiveType(), t.IsCapsuleType():
 		return t
 	case t.IsMapType():
@@ -149,7 +153,7 @@ func (t Type) WithoutOptionalAttributesDeep() Type {
 		return Object(attrTypes)
 	default:
 		// Should never happen, since above should be exhaustive
-		panic("WithoutOptionalAttributesDeep does not support the given type")
+		panic(fmt.Sprintf("WithoutOptionalAttributesDeep does not support the given type: %#v", t))
 	}
 }
 

--- a/cty/type_test.go
+++ b/cty/type_test.go
@@ -61,6 +61,10 @@ func TestWithoutOptionalAttributesDeep(t *testing.T) {
 		expected Type
 	}{
 		{
+			NilType,
+			NilType,
+		},
+		{
 			DynamicPseudoType,
 			DynamicPseudoType,
 		},


### PR DESCRIPTION
`NilType` is a valid type which was missed when listing all types under `WithoutOptionalAttributesDeep`. It should generally not appear here, but seems safe to account for in this case to prevent panics. If the `NilType` is not valid, then the caller will have to deal with that anyway.