### PR TITLE
account for null literal values in function args

### DIFF
--- a/cty/function/function.go
+++ b/cty/function/function.go
@@ -170,6 +170,12 @@ func (f Function) returnTypeForValues(args []cty.Value) (ty cty.Type, dynTypedAr
 			return cty.Type{}, false, NewArgErrorf(i, "argument must not be null")
 		}
 
+		if val.IsNull() && val.Type() == cty.DynamicPseudoType {
+			// this is a null literal, which is a known value and valid for any
+			// parameter type
+			continue
+		}
+
 		// AllowUnknown is ignored for type-checking, since we expect to be
 		// able to type check with unknown values. We *do* still need to deal
 		// with DynamicPseudoType here though, since the Type function might
@@ -203,6 +209,12 @@ func (f Function) returnTypeForValues(args []cty.Value) (ty cty.Type, dynTypedAr
 
 			if val.IsNull() && !spec.AllowNull {
 				return cty.Type{}, false, NewArgErrorf(realI, "argument must not be null")
+			}
+
+			if val.IsNull() && val.Type() == cty.DynamicPseudoType {
+				// this is a null literal, which is a known value and valid for
+				// any parameter type
+				continue
 			}
 
 			if val.Type() == cty.DynamicPseudoType {

--- a/cty/function/function_test.go
+++ b/cty/function/function_test.go
@@ -126,6 +126,20 @@ func TestReturnTypeForValues(t *testing.T) {
 			Spec: &Spec{
 				Params: []Parameter{
 					{
+						Type:      cty.Number,
+						AllowNull: true,
+					},
+				},
+				Type: StaticReturnType(cty.Number),
+				Impl: stubImpl,
+			},
+			Args:     []cty.Value{cty.NullVal(cty.DynamicPseudoType)},
+			WantType: cty.Number,
+		},
+		{
+			Spec: &Spec{
+				Params: []Parameter{
+					{
 						Type: cty.List(cty.DynamicPseudoType),
 					},
 				},


### PR DESCRIPTION
The common usage of cty will handle a null literal value as a `NullVal(DynamicPseudoType)`, which is a valid argument to any function parameter allowing nullable values even without AllowDynamicType. Rather than forcing callers to always convert arguments to take this case into account, we return the expected type since the null value is wholly known.