### PR TITLE
convert: prevent invalid types in dynamicReplace

### DIFF
--- a/cty/convert/public_test.go
+++ b/cty/convert/public_test.go
@@ -1770,6 +1770,30 @@ func TestConvert(t *testing.T) {
 			Type:  cty.String,
 			Want:  cty.UnknownVal(cty.String).RefineNotNull(),
 		},
+
+		// Make sure we get valid unknown attribute types when converting from
+		// a map to an object with optional attributes.
+		{
+			Value: cty.ObjectVal(map[string]cty.Value{
+				"TTTattr": cty.UnknownVal(cty.Map(cty.String)),
+			}),
+			Type: cty.Object(map[string]cty.Type{
+				"TTTattr": cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+					"string": cty.String,
+					"set":    cty.Set(cty.String),
+					"list":   cty.List(cty.String),
+					"map":    cty.Map(cty.String),
+				}, []string{"set", "list", "map"}),
+			}),
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"TTTattr": cty.UnknownVal(cty.Object(map[string]cty.Type{
+					"list":   cty.List(cty.String),
+					"map":    cty.Map(cty.String),
+					"set":    cty.Set(cty.String),
+					"string": cty.String,
+				})),
+			}),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
When converting an unknown map into an object with optional attributes, that object may have attributes which don't match the map element type. This conversion will be valid, but when building Null or Unknown values of that type we need to ensure all attributes have a valid type.

The fallthrough path for dynamicReplace when non-primitive types didn't match contained a cty.NilVal element type, which would result in an overall invalid type. We can use early returns to ensure there are no uninitialized values, and let the fallback use the original out type. Since at this point the types appear to not be convertible, we can assume they are from attributes which were skipped during conversion due to being optional, otherwise the conversion would not have been valid.

