### PR TITLE
Large integer comparisons and msgpack encoding

### DIFF
--- a/cty/msgpack/marshal.go
+++ b/cty/msgpack/marshal.go
@@ -32,7 +32,10 @@ func Marshal(val cty.Value, ty cty.Type) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := msgpack.NewEncoder(&buf)
 	enc.UseCompactInts(true)
-	enc.UseCompactFloats(true)
+
+	// UseCompactFloats can fail on some platforms due to undefined behavior of
+	// float conversions
+	enc.UseCompactFloats(false)
 
 	err := marshal(val, ty, path, enc)
 	if err != nil {

--- a/cty/msgpack/roundtrip_test.go
+++ b/cty/msgpack/roundtrip_test.go
@@ -85,6 +85,18 @@ func TestRoundTrip(t *testing.T) {
 			cty.Number,
 		},
 		{
+			cty.MustParseNumberVal("9223372036854775807"),
+			cty.Number,
+		},
+		{
+			cty.MustParseNumberVal("9223372036854775808"),
+			cty.Number,
+		},
+		{
+			cty.MustParseNumberVal("9223372036854775809"),
+			cty.Number,
+		},
+		{
 			awkwardFractionVal,
 			cty.Number,
 		},

--- a/cty/primitive_type.go
+++ b/cty/primitive_type.go
@@ -1,6 +1,8 @@
 package cty
 
-import "math/big"
+import (
+	"math/big"
+)
 
 // primitiveType is the hidden implementation of the various primitive types
 // that are exposed as variables in this package.
@@ -77,6 +79,18 @@ func rawNumberEqual(a, b *big.Float) bool {
 	case a.Sign() != b.Sign():
 		return false
 	default:
+		// First check if these are integers, and compare them directly. Floats
+		// need a more nuanced approach.
+		aInt, aAcc := a.Int(nil)
+		bInt, bAcc := b.Int(nil)
+		if aAcc != bAcc {
+			// only one is an exact integer value, so they can't be equal
+			return false
+		}
+		if aAcc == big.Exact {
+			return aInt.Cmp(bInt) == 0
+		}
+
 		// This format and precision matches that used by cty/json.Marshal,
 		// and thus achieves our definition of "two numbers are equal if
 		// we'd use the same JSON serialization for both of them".

--- a/cty/value_ops_test.go
+++ b/cty/value_ops_test.go
@@ -91,6 +91,11 @@ func TestValueEquals(t *testing.T) {
 			NumberFloatVal(1.22222),
 			BoolVal(true),
 		},
+		{
+			MustParseNumberVal("9223372036854775808"),
+			NumberFloatVal(float64(9223372036854775808)),
+			BoolVal(true),
+		},
 
 		// Strings
 		{


### PR DESCRIPTION
This is two related bugs merged into a single PR, but we can split this up if needed.

The first is that `Equals` uses the string formatting for number comparison, but the format depends on the precision of the `big.Float` which could be different even with equal numbers. While we rely on the formatting implementation for "fuzzy" matching of floats, integers can be compared exactly.

The related bug was in the compact floats implementation of msgpack. When setting `UseCompactFloats(true)`, the msgpack encoder uses the expression `float64(int64(n)) == n` to check if the number con be represented by an `int64`. this can fail for some values on certain architectures, because the result of a failed conversion is undefined and system dependent.