### PR TITLE
Add FromCtyValueTagged

### DIFF
--- a/cty/gocty/helpers.go
+++ b/cty/gocty/helpers.go
@@ -27,13 +27,13 @@ var stringType = reflect.TypeOf("")
 //
 // This function will panic if two fields within the struct are tagged with
 // the same cty attribute name.
-func structTagIndices(st reflect.Type) map[string]int {
+func structTagIndices(st reflect.Type, tag string) map[string]int {
 	ct := st.NumField()
 	ret := make(map[string]int, ct)
 
 	for i := 0; i < ct; i++ {
 		field := st.Field(i)
-		attrName := field.Tag.Get("cty")
+		attrName := field.Tag.Get(tag)
 		if attrName != "" {
 			ret[attrName] = i
 		}

--- a/cty/gocty/in.go
+++ b/cty/gocty/in.go
@@ -355,7 +355,7 @@ func toCtyObject(val reflect.Value, attrTypes map[string]cty.Type, path cty.Path
 		// path to give us a place to put our GetAttr step.
 		path = append(path, cty.PathStep(nil))
 
-		attrFields := structTagIndices(val.Type())
+		attrFields := structTagIndices(val.Type(), "cty")
 
 		vals := make(map[string]cty.Value, len(attrTypes))
 		for k, at := range attrTypes {

--- a/cty/gocty/out_test.go
+++ b/cty/gocty/out_test.go
@@ -374,6 +374,31 @@ func TestOut(t *testing.T) {
 	}
 }
 
+func TestOutOtherTags(t *testing.T) {
+	taggedCty, taggedOther := new(testStructManyTag), new(testStructManyTag)
+	err := FromCtyValueTagged(cty.ObjectVal(map[string]cty.Value{
+		"name": cty.StringVal("Eva"),
+	}), taggedCty, "cty")
+	if err != nil {
+		t.Fatalf("FromCtyValueTagged returned error: %s", err)
+	}
+
+	err = FromCtyValueTagged(cty.ObjectVal(map[string]cty.Value{
+		"another_name": cty.StringVal("Alice"),
+	}), taggedOther, "other")
+	if err != nil {
+		t.Fatalf("FromCtyValueTagged returned error: %s", err)
+	}
+
+	if taggedCty.Name != "Eva" {
+		t.Fatalf("taggedCty name mismatch: %s != Eva!", taggedCty.Name)
+	}
+
+	if taggedOther.Name != "Alice" {
+		t.Fatalf("taggedCty name mismatch: %s != Alice!", taggedOther.Name)
+	}
+}
+
 type testOutAssertFunc func(cty.Value, reflect.Type, interface{}, *testing.T)
 
 func testOutAssertPtrVal(want interface{}) testOutAssertFunc {
@@ -407,6 +432,10 @@ func testOutWrongResult(ctyValue cty.Value, targetType reflect.Type, got interfa
 type testStruct struct {
 	Name   string `cty:"name"`
 	Number *int   `cty:"number"`
+}
+
+type testStructManyTag struct {
+	Name string `cty:"name" other:"another_name"`
 }
 
 type testTupleStruct struct {


### PR DESCRIPTION
Like `FromCtyValue`, but you can pass in a different tag to decode with. Update code using literal `"cty"` to use a passed in tag string. Put the insides of `FromCtyValue` into `FromCtyValueTagged`, now `FromCtyValue` calls `FromCtyValueTagged` with literal `"cty"`.