### PR TITLE
Support IndexStep.Apply for element values

### DIFF
--- a/cty/path.go
+++ b/cty/path.go
@@ -212,6 +212,19 @@ func (s IndexStep) Apply(val Value) (Value, error) {
 		return NilVal, errors.New("cannot index a null value")
 	}
 
+	// For sets, IndexStep.Key is the value itself.
+	if val.Type().IsSetType() {
+		findElementResult := val.findElement(s.Key)
+		has, _ := findElementResult.hasElement.Unmark()
+		if !has.IsKnown() {
+			return UnknownVal(val.Type().ElementType()), nil
+		}
+		if !has.True() {
+			return NilVal, errors.New("value does not have given element")
+		}
+		return findElementResult.matchingElement, nil
+	}
+
 	switch s.Key.Type() {
 	case Number:
 		if !(val.Type().IsListType() || val.Type().IsTupleType()) {

--- a/cty/path_test.go
+++ b/cty/path_test.go
@@ -160,6 +160,30 @@ func TestPathApply(t *testing.T) {
 			cty.StringVal("there").Mark(1),
 			``,
 		},
+		{
+			cty.SetVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{"x": cty.StringVal("X1")}),
+				cty.ObjectVal(map[string]cty.Value{"x": cty.StringVal("X2")}),
+			}),
+			cty.IndexPath(cty.ObjectVal(map[string]cty.Value{"x": cty.StringVal("X1")})).GetAttr("x"),
+			cty.StringVal("X1"),
+			``,
+		},
+		{
+			cty.SetVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{"x": cty.StringVal("X1")}),
+				cty.ObjectVal(map[string]cty.Value{"x": cty.StringVal("X2")}),
+			}),
+			cty.IndexPath(cty.ObjectVal(map[string]cty.Value{"x": cty.StringVal("X3")})).GetAttr("x"),
+			cty.NilVal,
+			`at step 0: value does not have given element`,
+		},
+		{
+			cty.UnknownVal(cty.Set(cty.Object(map[string]cty.Type{"x": cty.String}))),
+			cty.IndexPath(cty.ObjectVal(map[string]cty.Value{"x": cty.StringVal("X3")})).GetAttr("x"),
+			cty.UnknownVal(cty.String),
+			``,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Enable IndexStep.Apply to find matching Set elements. This fixes https://github.com/zclconf/go-cty/issues/180