### PR TITLE
Reference the element its index to improve readability of the mismatch message

### DIFF
--- a/cty/convert/mismatch_msg.go
+++ b/cty/convert/mismatch_msg.go
@@ -170,6 +170,7 @@ func mismatchMessageCollectionsFromStructural(got, want cty.Type) string {
 			if conv := getConversion(gotEty, wantEty, true); conv != nil {
 				continue // conversion is available, so no problem
 			}
+			// since we receive an index, we add 1 to reference the element number
 			return fmt.Sprintf("element %d: %s", i+1, MismatchMessage(gotEty, wantEty))
 		}
 

--- a/cty/convert/mismatch_msg.go
+++ b/cty/convert/mismatch_msg.go
@@ -170,8 +170,7 @@ func mismatchMessageCollectionsFromStructural(got, want cty.Type) string {
 			if conv := getConversion(gotEty, wantEty, true); conv != nil {
 				continue // conversion is available, so no problem
 			}
-			// since we receive an index, we add 1 to reference the element number
-			return fmt.Sprintf("element %d: %s", i+1, MismatchMessage(gotEty, wantEty))
+			return fmt.Sprintf("element at index %d: %s", i, MismatchMessage(gotEty, wantEty))
 		}
 
 		// If we get down here then something weird is going on but we'll

--- a/cty/convert/mismatch_msg.go
+++ b/cty/convert/mismatch_msg.go
@@ -170,7 +170,7 @@ func mismatchMessageCollectionsFromStructural(got, want cty.Type) string {
 			if conv := getConversion(gotEty, wantEty, true); conv != nil {
 				continue // conversion is available, so no problem
 			}
-			return fmt.Sprintf("element %d: %s", i, MismatchMessage(gotEty, wantEty))
+			return fmt.Sprintf("element %d: %s", i+1, MismatchMessage(gotEty, wantEty))
 		}
 
 		// If we get down here then something weird is going on but we'll

--- a/cty/convert/mismatch_msg_test.go
+++ b/cty/convert/mismatch_msg_test.go
@@ -69,7 +69,7 @@ func TestMismatchMessage(t *testing.T) {
 			cty.List(cty.Object(map[string]cty.Type{
 				"foo": cty.String,
 			})),
-			`element 0: attribute "foo" is required`,
+			`element 1: attribute "foo" is required`,
 		},
 		{
 			cty.List(cty.EmptyObject),
@@ -83,7 +83,7 @@ func TestMismatchMessage(t *testing.T) {
 			cty.Set(cty.Object(map[string]cty.Type{
 				"foo": cty.String,
 			})),
-			`element 0: attribute "foo" is required`,
+			`element 1: attribute "foo" is required`,
 		},
 		{
 			cty.Map(cty.EmptyObject),

--- a/cty/convert/mismatch_msg_test.go
+++ b/cty/convert/mismatch_msg_test.go
@@ -69,7 +69,7 @@ func TestMismatchMessage(t *testing.T) {
 			cty.List(cty.Object(map[string]cty.Type{
 				"foo": cty.String,
 			})),
-			`element 1: attribute "foo" is required`,
+			`element at index 0: attribute "foo" is required`,
 		},
 		{
 			cty.List(cty.EmptyObject),
@@ -81,14 +81,14 @@ func TestMismatchMessage(t *testing.T) {
 		{
 			cty.Tuple([]cty.Type{cty.String, cty.EmptyObject}),
 			cty.List(cty.String),
-			`element 2: string required`,
+			`element at index 1: string required`,
 		},
 		{
 			cty.Tuple([]cty.Type{cty.EmptyObject}),
 			cty.Set(cty.Object(map[string]cty.Type{
 				"foo": cty.String,
 			})),
-			`element 1: attribute "foo" is required`,
+			`element at index 0: attribute "foo" is required`,
 		},
 		{
 			cty.Map(cty.EmptyObject),

--- a/cty/convert/mismatch_msg_test.go
+++ b/cty/convert/mismatch_msg_test.go
@@ -79,6 +79,11 @@ func TestMismatchMessage(t *testing.T) {
 			`incorrect set element type: attribute "foo" is required`,
 		},
 		{
+			cty.Tuple([]cty.Type{cty.String, cty.EmptyObject}),
+			cty.List(cty.String),
+			`element 2: string required`,
+		},
+		{
 			cty.Tuple([]cty.Type{cty.EmptyObject}),
 			cty.Set(cty.Object(map[string]cty.Type{
 				"foo": cty.String,

--- a/cty/tuple_type.go
+++ b/cty/tuple_type.go
@@ -78,7 +78,7 @@ func init() {
 	}
 }
 
-// IsTupleType returns true if the given type is an object type, regardless
+// IsTupleType returns true if the given type is a tuple type, regardless
 // of its element type.
 func (t Type) IsTupleType() bool {
 	_, ok := t.typeImpl.(typeTuple)


### PR DESCRIPTION
Fixes #189

```
  $ go test -run "TestMismatchMessage" -v
=== RUN   TestMismatchMessage
=== RUN   TestMismatchMessage/cty.Bool_but_want_cty.Number
=== RUN   TestMismatchMessage/cty.EmptyObject_but_want_cty.Object(map[string]cty.Type{"foo":cty.String})
=== RUN   TestMismatchMessage/cty.EmptyObject_but_want_cty.Object(map[string]cty.Type{"bar":cty.String,_"foo":cty.String})
=== RUN   TestMismatchMessage/cty.EmptyObject_but_want_cty.Object(map[string]cty.Type{"bar":cty.String,_"baz":cty.String,_"foo":cty.String})
=== RUN   TestMismatchMessage/cty.EmptyObject_but_want_cty.List(cty.Object(map[string]cty.Type{"bar":cty.String,_"baz":cty.String,_"foo":cty.String}))
=== RUN   TestMismatchMessage/cty.List(cty.String)_but_want_cty.List(cty.Object(map[string]cty.Type{"foo":cty.String}))
=== RUN   TestMismatchMessage/cty.List(cty.EmptyObject)_but_want_cty.List(cty.Object(map[string]cty.Type{"foo":cty.String}))
=== RUN   TestMismatchMessage/cty.Tuple([]cty.Type{cty.EmptyObject})_but_want_cty.List(cty.Object(map[string]cty.Type{"foo":cty.String}))
=== RUN   TestMismatchMessage/cty.List(cty.EmptyObject)_but_want_cty.Set(cty.Object(map[string]cty.Type{"foo":cty.String}))
=== RUN   TestMismatchMessage/cty.Tuple([]cty.Type{cty.String,_cty.EmptyObject})_but_want_cty.List(cty.String)
=== RUN   TestMismatchMessage/cty.Tuple([]cty.Type{cty.EmptyObject})_but_want_cty.Set(cty.Object(map[string]cty.Type{"foo":cty.String}))
=== RUN   TestMismatchMessage/cty.Map(cty.EmptyObject)_but_want_cty.Map(cty.Object(map[string]cty.Type{"foo":cty.String}))
=== RUN   TestMismatchMessage/cty.Object(map[string]cty.Type{"boop":cty.EmptyObject})_but_want_cty.Map(cty.Object(map[string]cty.Type{"foo":cty.String}))
=== RUN   TestMismatchMessage/cty.Tuple([]cty.Type{cty.EmptyObject,_cty.EmptyTuple})_but_want_cty.List(cty.DynamicPseudoType)
=== RUN   TestMismatchMessage/cty.Object(map[string]cty.Type{"bar":cty.String,_"baz":cty.Object(map[string]cty.Type{"boop":cty.Number}),_"foo":cty.Bool})_but_want_cty.Object(map[string]cty.Type{"bar":cty.String,_"baz":cty.Object(map[string]cty.Type{"beep":cty.Bool,_"boop":cty.Number}),_"foo":cty.Bool})
--- PASS: TestMismatchMessage (0.00s)
    --- PASS: TestMismatchMessage/cty.Bool_but_want_cty.Number (0.00s)
    --- PASS: TestMismatchMessage/cty.EmptyObject_but_want_cty.Object(map[string]cty.Type{"foo":cty.String}) (0.00s)
    --- PASS: TestMismatchMessage/cty.EmptyObject_but_want_cty.Object(map[string]cty.Type{"bar":cty.String,_"foo":cty.String}) (0.00s)
    --- PASS: TestMismatchMessage/cty.EmptyObject_but_want_cty.Object(map[string]cty.Type{"bar":cty.String,_"baz":cty.String,_"foo":cty.String}) (0.00s)
    --- PASS: TestMismatchMessage/cty.EmptyObject_but_want_cty.List(cty.Object(map[string]cty.Type{"bar":cty.String,_"baz":cty.String,_"foo":cty.String})) (0.00s)
    --- PASS: TestMismatchMessage/cty.List(cty.String)_but_want_cty.List(cty.Object(map[string]cty.Type{"foo":cty.String})) (0.00s)
    --- PASS: TestMismatchMessage/cty.List(cty.EmptyObject)_but_want_cty.List(cty.Object(map[string]cty.Type{"foo":cty.String})) (0.00s)
    --- PASS: TestMismatchMessage/cty.Tuple([]cty.Type{cty.EmptyObject})_but_want_cty.List(cty.Object(map[string]cty.Type{"foo":cty.String})) (0.00s)
    --- PASS: TestMismatchMessage/cty.List(cty.EmptyObject)_but_want_cty.Set(cty.Object(map[string]cty.Type{"foo":cty.String})) (0.00s)
    --- PASS: TestMismatchMessage/cty.Tuple([]cty.Type{cty.String,_cty.EmptyObject})_but_want_cty.List(cty.String) (0.00s)
    --- PASS: TestMismatchMessage/cty.Tuple([]cty.Type{cty.EmptyObject})_but_want_cty.Set(cty.Object(map[string]cty.Type{"foo":cty.String})) (0.00s)
    --- PASS: TestMismatchMessage/cty.Map(cty.EmptyObject)_but_want_cty.Map(cty.Object(map[string]cty.Type{"foo":cty.String})) (0.00s)
    --- PASS: TestMismatchMessage/cty.Object(map[string]cty.Type{"boop":cty.EmptyObject})_but_want_cty.Map(cty.Object(map[string]cty.Type{"foo":cty.String})) (0.00s)
    --- PASS: TestMismatchMessage/cty.Tuple([]cty.Type{cty.EmptyObject,_cty.EmptyTuple})_but_want_cty.List(cty.DynamicPseudoType) (0.00s)
    --- PASS: TestMismatchMessage/cty.Object(map[string]cty.Type{"bar":cty.String,_"baz":cty.Object(map[string]cty.Type{"boop":cty.Number}),_"foo":cty.Bool})_but_want_cty.Object(map[string]cty.Type{"bar":cty.String,_"baz":cty.Object(map[string]cty.Type{"beep":cty.Bool,_"boop":cty.Number}),_"foo":cty.Bool}) (0.00s)
PASS
ok      github.com/zclconf/go-cty/cty/convert   0.611s
```