### PR TITLE
[stdlib] Add StrContains function

### DIFF
--- a/cty/function/stdlib/string.go
+++ b/cty/function/stdlib/string.go
@@ -78,6 +78,30 @@ var ReverseFunc = function.New(&function.Spec{
 	},
 })
 
+var StrContainsFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "str",
+			Type: cty.String,
+		},
+		{
+			Name: "substr",
+			Type: cty.String,
+		},
+	},
+	Type: function.StaticReturnType(cty.Bool),
+	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
+		str := args[0].AsString()
+		substr := args[1].AsString()
+
+		if strings.Contains(str, substr) {
+			return cty.True, nil
+		}
+
+		return cty.False, nil
+	},
+})
+
 var StrlenFunc = function.New(&function.Spec{
 	Description: "Returns the number of Unicode characters (technically: grapheme clusters) in the given string.",
 	Params: []function.Parameter{
@@ -538,6 +562,12 @@ func Lower(str cty.Value) (cty.Value, error) {
 // single character.
 func Reverse(str cty.Value) (cty.Value, error) {
 	return ReverseFunc.Call([]cty.Value{str})
+}
+
+// StrContains searches a given string for another given substring,
+// if found the function returns true, otherwise returns false.
+func StrContains(str, substr cty.Value) (cty.Value, error) {
+	return StrContainsFunc.Call([]cty.Value{str, substr})
 }
 
 // Strlen is a Function that returns the length of the given string in

--- a/cty/function/stdlib/string_test.go
+++ b/cty/function/stdlib/string_test.go
@@ -273,6 +273,65 @@ func TestStrlen(t *testing.T) {
 	}
 }
 
+func TestStrContains(t *testing.T) {
+	tests := []struct {
+		String cty.Value
+		Substr cty.Value
+		Want   cty.Value
+		Err    bool
+	}{
+		{
+			cty.StringVal("hello"),
+			cty.StringVal("hel"),
+			cty.BoolVal(true),
+			false,
+		},
+		{
+			cty.StringVal("hello"),
+			cty.StringVal("lo"),
+			cty.BoolVal(true),
+			false,
+		},
+		{
+			cty.StringVal("hello1"),
+			cty.StringVal("1"),
+			cty.BoolVal(true),
+			false,
+		},
+		{
+			cty.StringVal("hello1"),
+			cty.StringVal("heo"),
+			cty.BoolVal(false),
+			false,
+		},
+		{
+			cty.StringVal("hello1"),
+			cty.NumberIntVal(1),
+			cty.UnknownVal(cty.Bool),
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("includes(%#v, %#v)", test.String, test.Substr), func(t *testing.T) {
+			got, err := StrContains(test.String, test.Substr)
+
+			if test.Err {
+				if err == nil {
+					t.Fatal("succeeded; want error")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}
+
 func TestSubstr(t *testing.T) {
 	tests := []struct {
 		Input  cty.Value


### PR DESCRIPTION
This PR will add a `StrContains` function for checking if a string contains another string. The motivation for this is to eventually use the function over in https://github.com/hashicorp/packer/blob/069a6ed62fd359644e4392000d8f6488851ddd74/hcl2template/functions.go#L26-L32 so that within Packer's HCL2 config format we can easily use a `strcontains` function. The logic is identical to what already exists over in Terraform here https://github.com/hashicorp/terraform/blob/b40c1d3b743854db715c70c0840e6b753c80bc9a/internal/lang/funcs/string.go#L137-L161 

By exposing a `strcontains` function here and eventually in Packer, we will dramatically simplify a simple string comparison check within Packer HCL2 templates. 