### PR TITLE
Try ConversionFrom if ConversionTo returns nil

### DIFF
--- a/cty/convert/conversion.go
+++ b/cty/convert/conversion.go
@@ -171,12 +171,16 @@ func getConversionKnown(in cty.Type, out cty.Type, unsafe bool) conversion {
 		}
 		if out.IsCapsuleType() {
 			if fn := out.CapsuleOps().ConversionTo; fn != nil {
-				return conversionToCapsule(in, out, fn)
+				if conv := conversionToCapsule(in, out, fn); conv != nil {
+					return conv
+				}
 			}
 		}
 		if in.IsCapsuleType() {
 			if fn := in.CapsuleOps().ConversionFrom; fn != nil {
-				return conversionFromCapsule(in, out, fn)
+				if conv := conversionFromCapsule(in, out, fn); conv != nil {
+					return conv
+				}
 			}
 		}
 		// No conversion operation is available, then.

--- a/cty/convert/conversion_capsule_test.go
+++ b/cty/convert/conversion_capsule_test.go
@@ -46,6 +46,20 @@ func TestConvertCapsuleType(t *testing.T) {
 		return cty.CapsuleVal(capTy, &s)
 	}
 
+	capIntTy := cty.CapsuleWithOps("int test thingy", reflect.TypeOf(0), &cty.CapsuleOps{
+		ConversionFrom: func(src cty.Type) func(interface{}, cty.Path) (cty.Value, error) {
+			if src.Equals(capTy) {
+				return func(v interface{}, p cty.Path) (cty.Value, error) {
+					return capVal(fmt.Sprintf("%d", *(v.(*int)))), nil
+				}
+			}
+			return nil
+		},
+	})
+	capIntVal := func(i int) cty.Value {
+		return cty.CapsuleVal(capIntTy, &i)
+	}
+
 	tests := []struct {
 		From    cty.Value
 		To      cty.Type
@@ -101,6 +115,11 @@ func TestConvertCapsuleType(t *testing.T) {
 			From:    cty.NullVal(capTy),
 			To:      cty.Bool,
 			WantErr: `bool required`,
+		},
+		{
+			From: capIntVal(42),
+			To:   capTy,
+			Want: capVal("42"),
 		},
 	}
 


### PR DESCRIPTION
Currently when converting between two capsule types if `ConversionTo` returns `nil` then the conversion fails, even if the target type defines a suitable `ConversionFrom`.

<details>

<summary>Example</summary>

```go
package main

import (
	"fmt"
	"log"
	"reflect"

	"github.com/zclconf/go-cty/cty"
	"github.com/zclconf/go-cty/cty/convert"
)

func main() {
	myStringType := cty.CapsuleWithOps("MyString", reflect.TypeOf(""), &cty.CapsuleOps{
		ConversionTo: func(dst cty.Type) func(cty.Value, cty.Path) (interface{}, error) {
			// conversions to some types other than myIntType defined here
			// returns nil when asked to convert to the myIntType
			return nil
		},
	})
	myIntType := cty.CapsuleWithOps("MyInt", reflect.TypeOf(0), &cty.CapsuleOps{
		ConversionFrom: func(src cty.Type) func(interface{}, cty.Path) (cty.Value, error) {
			if src.Equals(myStringType) {
				return func(v interface{}, p cty.Path) (cty.Value, error) {
					val := fmt.Sprintf("%d", *(v.(*int)))
					return cty.CapsuleVal(
						myStringType,
						&val,
					), nil
				}
			}
			return nil
		},
	})
	val := 42
	myInt := cty.CapsuleVal(myIntType, &val)
	myString, err := convert.Convert(myInt, myStringType)
	if err != nil {
		log.Fatalf("Cannot convert: %s", err)
	}
	log.Printf("Conversion successful: %#v", *(myString.EncapsulatedValue().(*string)))
}
```

</details>

This PR checks the `ConversionFrom` if `ConversionTo` fails