### PR TITLE
function: Ensure unexpected unknown values retain marks

### DIFF
--- a/cty/function/function.go
+++ b/cty/function/function.go
@@ -286,7 +286,7 @@ func (f Function) Call(args []cty.Value) (val cty.Value, err error) {
 		val := posArgs[i]
 
 		if !val.IsKnown() && !spec.AllowUnknown {
-			return cty.UnknownVal(expectedType), nil
+			return cty.UnknownVal(expectedType).WithMarks(val.Marks()), nil
 		}
 
 		if !spec.AllowMarked {
@@ -311,7 +311,7 @@ func (f Function) Call(args []cty.Value) (val cty.Value, err error) {
 		spec := f.spec.VarParam
 		for i, val := range varArgs {
 			if !val.IsKnown() && !spec.AllowUnknown {
-				return cty.UnknownVal(expectedType), nil
+				return cty.UnknownVal(expectedType).WithMarks(val.Marks()), nil
 			}
 			if !spec.AllowMarked {
 				unwrappedVal, marks := val.UnmarkDeep()

--- a/cty/function/function_test.go
+++ b/cty/function/function_test.go
@@ -486,6 +486,49 @@ func TestFunctionWithNewDescriptions(t *testing.T) {
 	})
 }
 
+func TestFunctionCallWithUnknownVals(t *testing.T) {
+	t.Run("params", func(t *testing.T) {
+		f := New(&Spec{
+			Params: []Parameter{
+				{
+					Name: "foo",
+					Type: cty.String,
+				},
+			},
+			Type: StaticReturnType(cty.String),
+			Impl: stubImpl,
+		})
+		marks := cty.NewValueMarks("special", "extra")
+		unknownWithMarks := cty.UnknownVal(cty.String).WithMarks(marks)
+		got, err := f.Call([]cty.Value{unknownWithMarks})
+		if err != nil {
+			t.Error(err)
+		}
+		if !marks.Equal(got.Marks()) {
+			t.Errorf("unexpected marks\ngot:  %s\nwant: %s", got.Marks(), marks)
+		}
+	})
+	t.Run("varparam", func(t *testing.T) {
+		f := New(&Spec{
+			VarParam: &Parameter{
+				Name: "foo",
+				Type: cty.String,
+			},
+			Type: StaticReturnType(cty.String),
+			Impl: stubImpl,
+		})
+		marks := cty.NewValueMarks("special", "extra")
+		unknownWithMarks := cty.UnknownVal(cty.String).WithMarks(marks)
+		got, err := f.Call([]cty.Value{unknownWithMarks})
+		if err != nil {
+			t.Error(err)
+		}
+		if !marks.Equal(got.Marks()) {
+			t.Errorf("unexpected marks\ngot:  %s\nwant: %s", got.Marks(), marks)
+		}
+	})
+}
+
 func stubType([]cty.Value) (cty.Type, error) {
 	return cty.NilType, fmt.Errorf("should not be called")
 }


### PR DESCRIPTION
This is intended to be a relatively minor change which would help us do validation of (un)expected marks earlier.

Specifically, in Terraform `validate` command always deals with unknown values and as a result the extent of the validation is limited. `plan` works with "more known" values. In this instance the goal is that we can tell the user the following is invalid during `validate` phase, instead of delaying it until `plan`:

```hcl
output "expected-not-marked" {
    value = func(var.marked)
}
```
where `func()` could be any function, such as [`stdlib.LowerFunc`](https://github.com/zclconf/go-cty/blob/ea922e7a95ba2be57897697117f318670e066d22/cty/function/stdlib/string.go#L34-L50). I know it won't cover all cases but this appears to be minimal enough change that still brings benefits.

A few other cases which I'm aware of this PR is not covering:
- `func(unknown-unmarked-arg, unknown-marked-arg)`
- `func(dynamic-arg)`

Also, naturally any function may still decide to deal with marks in its own appropriate way - and [some in Terraform already do](https://github.com/hashicorp/terraform/blob/d55512c0d815551ff87084180d4729fb6e479102/internal/lang/funcs/collection.go#L42-L51). I anticipate that eventually more of the existing functions will do so and so the codepath being edited here would be hit less often.