### PR TITLE
convert: strip optional attributes out of empty maps

### DIFF
--- a/cty/convert/conversion_collection.go
+++ b/cty/convert/conversion_collection.go
@@ -162,7 +162,7 @@ func conversionCollectionToMap(ety cty.Type, conv conversion) conversion {
 			if ety == cty.DynamicPseudoType {
 				return cty.MapValEmpty(val.Type().ElementType()), nil
 			}
-			return cty.MapValEmpty(ety), nil
+			return cty.MapValEmpty(ety.WithoutOptionalAttributesDeep()), nil
 		}
 
 		if ety.IsCollectionType() || ety.IsObjectType() {

--- a/cty/convert/public_test.go
+++ b/cty/convert/public_test.go
@@ -1794,6 +1794,36 @@ func TestConvert(t *testing.T) {
 				})),
 			}),
 		},
+
+		{
+			Value: cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"optional_map": cty.EmptyObjectVal,
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"optional_map": cty.MapValEmpty(cty.Object(map[string]cty.Type{
+						"asdf": cty.String,
+					})),
+				}),
+			}),
+			Type: cty.Set(cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+				"optional_map": cty.Map(cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+					"asdf": cty.String,
+				}, []string{"asdf"})),
+			}, []string{"optional_map"})),
+			Want: cty.SetVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"optional_map": cty.MapValEmpty(cty.Object(map[string]cty.Type{
+						"asdf": cty.String,
+					})),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"optional_map": cty.MapValEmpty(cty.Object(map[string]cty.Type{
+						"asdf": cty.String,
+					})),
+				}),
+			}),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
We had previously fixed this for lists and sets in https://github.com/zclconf/go-cty/pull/135.

There's a [thread](https://github.com/zclconf/go-cty/pull/135#issuecomment-1273366490) in that PR that asks why not for maps as well. At the time the issue wasn't being reproduced for maps in the same way because maps perform a post-conversion unification [here](https://github.com/zclconf/go-cty/blob/main/cty/convert/conversion_collection.go#L168-L173). This was stripping the optional attributes out in the original test case for maps, explaining why we didn't see this in maps before.

The new test cases uses maps in a way that the unification logic isn't called (by only using empty maps without nesting) and now exposes the same problem.

@apparentlymart, I'm not sure if we also want to add the same unification logic to the other collections as well? But either way, I think stripping the optional attributes out of the map is the right thing to do and I probably should have just done it last time even though there was some unexplained behaviour as to why it wasn't needed. 