### PR TITLE
element(): support negative indices in tuples

### DIFF
--- a/cty/function/stdlib/collection.go
+++ b/cty/function/stdlib/collection.go
@@ -170,6 +170,9 @@ var ElementFunc = function.New(&function.Spec{
 				return cty.DynamicPseudoType, errors.New("cannot use element function with an empty list")
 			}
 			index = index % len(etys)
+			if index < 0 {
+				index += len(etys)
+			}
 			return etys[index], nil
 		default:
 			return cty.DynamicPseudoType, fmt.Errorf("cannot read elements from %s", listTy.FriendlyName())

--- a/cty/function/stdlib/collection_test.go
+++ b/cty/function/stdlib/collection_test.go
@@ -1138,6 +1138,12 @@ func TestElement(t *testing.T) {
 		cty.StringVal("brown").Mark("fox"),
 		cty.UnknownVal(cty.String),
 	})
+	tupleOfStrings := cty.TupleVal([]cty.Value{
+		cty.StringVal("the"),
+		cty.StringVal("quick"),
+		cty.StringVal("brown"),
+		cty.StringVal("fox"),
+	})
 
 	tests := []struct {
 		List  cty.Value
@@ -1252,6 +1258,18 @@ func TestElement(t *testing.T) {
 			cty.MustParseNumberVal("9223372036854775808"),
 			cty.StringVal("fox"),
 			true,
+		},
+		{
+			tupleOfStrings,
+			cty.NumberIntVal(2),
+			cty.StringVal("brown"),
+			false,
+		},
+		{
+			tupleOfStrings,
+			cty.NumberIntVal(-1),
+			cty.StringVal("fox"),
+			false,
 		},
 	}
 


### PR DESCRIPTION
Support was added for negative indices in https://github.com/zclconf/go-cty/commit/7b73cce468e8021d933cfb7990356837c6348146. This change actually only supports lists, while tuples continued to error. This PR adds the same fix for the tuple branch when calculating the return type.

@apparentlymart - it might be that you actually don't want to support this (since tuples have a concretely known length) but it was super quick for me to raise this to start the discussion. I do note the changelog entry just says the element function now accepts negative numbers without clarification that this is only for lists and not tuples.

From Terraform's perspective, users don't really differentiate between a tuple and a list - they just want to execute element([0, 1, 2], -1) without having to wrap the tuple in a `tolist(...)` call first. I can see arguments for both sides <shrug>