### PR TITLE
function: Handle nested null values in `ReturnTypeForValues`

### DIFF
--- a/cty/function/function_test.go
+++ b/cty/function/function_test.go
@@ -178,6 +178,104 @@ func TestReturnTypeForValues(t *testing.T) {
 			},
 			WantType: cty.Number,
 		},
+		{
+			Spec: &Spec{
+				Params: []Parameter{
+					{
+						Type: cty.String,
+					},
+				},
+				Type: StaticReturnType(cty.String),
+				Impl: stubImpl,
+			},
+			Args: []cty.Value{
+				cty.NilVal,
+			},
+			WantType: cty.String,
+			WantErr:  true,
+		},
+		{
+			Spec: &Spec{
+				Params: []Parameter{
+					{
+						Type: cty.List(cty.String),
+					},
+				},
+				Type: StaticReturnType(cty.List(cty.String)),
+				Impl: stubImpl,
+			},
+			Args: []cty.Value{
+				cty.ListVal([]cty.Value{cty.NilVal}),
+			},
+			WantType: cty.List(cty.String),
+			WantErr:  true,
+		},
+		{
+			Spec: &Spec{
+				Params: []Parameter{
+					{
+						Type: cty.List(cty.String),
+					},
+				},
+				Type: StaticReturnType(cty.List(cty.String)),
+				Impl: stubImpl,
+			},
+			Args: []cty.Value{
+				cty.UnknownAsNull(cty.ListVal([]cty.Value{cty.NilVal})),
+			},
+			WantType: cty.List(cty.String),
+			WantErr:  true,
+		},
+		{
+			Spec: &Spec{
+				Params: []Parameter{
+					{
+						Type: cty.Set(cty.String),
+					},
+				},
+				Type: StaticReturnType(cty.Set(cty.String)),
+				Impl: stubImpl,
+			},
+			Args: []cty.Value{
+				cty.SetVal([]cty.Value{cty.NilVal}),
+			},
+			WantType: cty.Set(cty.String),
+			WantErr:  true,
+		},
+		{
+			Spec: &Spec{
+				Params: []Parameter{
+					{
+						Type: cty.Tuple([]cty.Type{cty.String}),
+					},
+				},
+				Type: StaticReturnType(cty.Tuple([]cty.Type{cty.String})),
+				Impl: stubImpl,
+			},
+			Args: []cty.Value{
+				cty.TupleVal([]cty.Value{cty.NilVal}),
+			},
+			WantType: cty.Tuple([]cty.Type{cty.String}),
+			WantErr:  true,
+		},
+		{
+			Spec: &Spec{
+				Params: []Parameter{
+					{
+						Type: cty.Map(cty.String),
+					},
+				},
+				Type: StaticReturnType(cty.Map(cty.String)),
+				Impl: stubImpl,
+			},
+			Args: []cty.Value{
+				cty.MapVal(map[string]cty.Value{
+					"test": cty.NilVal,
+				}),
+			},
+			WantType: cty.Map(cty.String),
+			WantErr:  true,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
As demonstrated in tests and initially reported in https://github.com/hashicorp/terraform/issues/36547

The following

- `(Function).ReturnTypeForValues(cty.ListVal(cty.NilVal))`
- `(Function).ReturnTypeForValues(cty.SetVal(cty.NilVal))`
- `(Function).ReturnTypeForValues(cty.MapVal(map[string]cty.Value{"k": cty.NilVal}))`
- `(Function).ReturnTypeForValues(cty.TupleVal([]cty.Value{cty.NilVal})`

currently panics at https://github.com/zclconf/go-cty/blob/67d85b647e726fed180cfeeb63161cb341582f36/cty/type_conform.go#L137 because nil type doesn't implement `FriendlyName()` which AFAICT is by design.

As for the proposed implementation - this makes `AllowNull` to mean "allow null anywhere in any complex value".

Relatedly, the default behaviour (`AllowNull: false`) now requires the given value not have null _anywhere_ in complex types/values. I think this is a reasonable default behaviour but I'm open to alternative suggestions.

---

Some other solutions I didn't implement:

1. `IsNull` could mean "contains null" by default
2. A new public method `ContainsNull` could be exposed

I'm open to either of the two though.