### PR TITLE
convert: Add got type FriendlyName to default error message

### DIFF
--- a/cty/convert/mismatch_msg.go
+++ b/cty/convert/mismatch_msg.go
@@ -55,7 +55,7 @@ func MismatchMessage(got, want cty.Type) string {
 
 	default:
 		// If we have nothing better to say, we'll just state what was required.
-		return want.FriendlyNameForConstraint() + " required"
+		return want.FriendlyNameForConstraint() + " required but " + got.FriendlyName() + " was given"
 	}
 }
 


### PR DESCRIPTION
`Inappropriate value for attribute "vpc_id": string required.`

![image](https://github.com/user-attachments/assets/a202de39-0fec-4723-b155-169bbc890c62)

Fixes https://github.com/zclconf/go-cty/issues/208