### PR TITLE
feat: add support for time.Duration parsing from HCL string

### DIFF
--- a/cty/value_init.go
+++ b/cty/value_init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"time"
 
 	"github.com/zclconf/go-cty/cty/ctystrings"
 	"github.com/zclconf/go-cty/cty/set"
@@ -50,6 +51,10 @@ func ParseNumberVal(s string) (Value, error) {
 	// way to handle numbers arriving as strings.
 	f, _, err := big.ParseFloat(s, 10, 512, big.ToNearestEven)
 	if err != nil {
+		// The string is defined as a duration? try parse it.
+		if val, err := time.ParseDuration(s); err == nil {
+			return NumberIntVal(val.Nanoseconds()), nil
+		}
 		return NilVal, fmt.Errorf("a number is required")
 	}
 	return NumberVal(f), nil

--- a/cty/value_init_test.go
+++ b/cty/value_init_test.go
@@ -2,7 +2,9 @@ package cty
 
 import (
 	"fmt"
+	"math/big"
 	"testing"
+	"time"
 )
 
 func TestSetVal(t *testing.T) {
@@ -429,6 +431,43 @@ func TestCanMapVal(t *testing.T) {
 		got := CanMapVal(tc.Elems)
 		if got != tc.Want {
 			t.Errorf("wrong result for elements %#v:\ngot %v, want %v", tc.Elems, got, tc.Want)
+		}
+	}
+}
+
+func TestParseNumberVal(t *testing.T) {
+	testCases := []struct {
+		Input string
+		Want  Value
+	}{
+		{
+			"123",
+			NumberIntVal(123),
+		},
+		{
+			"123ns",
+			NumberIntVal(123),
+		},
+		{
+			"123s",
+			NumberIntVal(123 * time.Second.Nanoseconds()),
+		},
+		{
+			"123h",
+			NumberIntVal(123 * time.Hour.Nanoseconds()),
+		},
+	}
+
+	for _, tc := range testCases {
+		got, err := ParseNumberVal(tc.Input)
+		if err != nil {
+			t.Errorf("unexpected error for input %#v: %s", tc.Input, err)
+		}
+
+		v1 := got.v.(*big.Float)
+		v2 := tc.Want.v.(*big.Float)
+		if v1.Cmp(v2) != 0 {
+			t.Errorf("wrong result for input %#v:\ngot %#v, want %#v", tc.Input, v1, v2)
 		}
 	}
 }


### PR DESCRIPTION
This change enables parsing time.Duration fields from HCL string values. 

For example:
```go
  type Value struct {
      Dur time.Duration `hcl:"dur"`
  }
```

Can now be defined in HCL as:
```hcl
  data = {
      dur = "10s" // 10h, 20m, 30s, 500ms...
  }
```